### PR TITLE
Recommend OS CLI tools over keyring library for interpreted-language CLIs

### DIFF
--- a/skills/app-secret-management/SKILL.md
+++ b/skills/app-secret-management/SKILL.md
@@ -64,9 +64,9 @@ code examples.
 (`security` on macOS, `secret-tool` on Linux) over library-based keyring access.
 On macOS, keychain ACLs are tied to the interpreter binary path — when it
 changes (venv rebuild, version upgrade, `nvm use`), every keychain entry
-requires re-authorization. OS CLI tools are system-signed with stable paths and
-never trigger re-auth. See the reference doc for code examples and fallback
-guidance.
+requires re-authorization. OS CLI tools have stable binary identity
+(system-signed, fixed paths), avoiding this re-authorization churn. See the
+reference doc for code examples and fallback guidance.
 
 **Daemons:** If the service runs in user context (LaunchAgent, systemd user
 service), keyring access works normally. If headless or root, the keyring may be

--- a/skills/app-secret-management/SKILL.md
+++ b/skills/app-secret-management/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: MIT
 metadata:
   author: natecostello
-  version: "3.0"
+  version: "3.1"
 ---
 
 # App Secret Management
@@ -58,7 +58,15 @@ choosing between them.
 Use the platform's keyring abstraction. Never store secrets in plaintext config
 files or databases. See
 [keyring-by-framework.md](references/keyring-by-framework.md) for per-framework
-code examples (Python `keyring`, Electron `safeStorage`, Tauri, Swift, DPAPI).
+code examples.
+
+**Interpreted-language CLIs (Python, Node, Ruby):** Prefer OS CLI tools
+(`security` on macOS, `secret-tool` on Linux) over library-based keyring access.
+On macOS, keychain ACLs are tied to the interpreter binary path — when it
+changes (venv rebuild, version upgrade, `nvm use`), every keychain entry
+requires re-authorization. OS CLI tools are system-signed with stable paths and
+never trigger re-auth. See the reference doc for code examples and fallback
+guidance.
 
 **Daemons:** If the service runs in user context (LaunchAgent, systemd user
 service), keyring access works normally. If headless or root, the keyring may be
@@ -150,7 +158,10 @@ Automate in a dotfile manager (chezmoi `run_once`) for unattended bootstrap.
   and fall back to cached values if available.
 - **Headless/CI** — `backup_backend: none`, read secrets from env vars
   (`MYAPP_SECRET_<NAME>`) or CI secrets manager when keyring is unavailable.
-- **macOS code signing** — data protection keychain requires signed binary with
+- **macOS binary identity** — interpreted-language CLIs (Python, Node, Ruby)
+  should use OS CLI tools to avoid re-authorization prompts when the interpreter
+  binary path changes. See [keyring-by-framework.md](references/keyring-by-framework.md).
+  For native apps, data protection keychain requires signed binary with
   entitlements. Test unsigned dev builds against legacy keychain.
 - **Bootstrap secret for daemon SDK** — service account token stored on disk has
   same trust model as age identity file. Protect with filesystem permissions.

--- a/skills/app-secret-management/references/keyring-by-framework.md
+++ b/skills/app-secret-management/references/keyring-by-framework.md
@@ -16,15 +16,18 @@ entry. This is a fundamental macOS security model constraint with no upstream fi
 authorized (system-signed binaries with stable paths) and never trigger re-auth.
 
 **macOS** — `security` (Apple-signed, always in `/usr/bin/`):
+
+> **Note:** `-w` passes the password via process argv, which is briefly visible
+> to other processes (e.g., `ps`). This is the standard `security` CLI interface
+> and is generally accepted for CLI tools on macOS. For high-sensitivity secrets,
+> consider the encrypted store approach (single keychain entry) to minimize
+> exposure — see [runtime-storage-tradeoffs.md](runtime-storage-tradeoffs.md).
+
 ```python
-import subprocess, json
+import subprocess
 
 def keychain_set(service: str, account: str, password: str) -> None:
-    # delete first to avoid "already exists" error on update
-    subprocess.run(
-        ["security", "delete-generic-password", "-s", service, "-a", account],
-        capture_output=True,  # ignore "not found" errors
-    )
+    # -U updates the item if it already exists, or creates it if not
     subprocess.run(
         ["security", "add-generic-password", "-s", service, "-a", account,
          "-w", password, "-U"],
@@ -39,9 +42,10 @@ def keychain_get(service: str, account: str) -> str | None:
     return r.stdout.strip() if r.returncode == 0 else None
 
 def keychain_delete(service: str, account: str) -> None:
+    # Idempotent — succeeds silently if the entry doesn't exist
     subprocess.run(
         ["security", "delete-generic-password", "-s", service, "-a", account],
-        check=True,
+        capture_output=True,
     )
 ```
 

--- a/skills/app-secret-management/references/keyring-by-framework.md
+++ b/skills/app-secret-management/references/keyring-by-framework.md
@@ -46,11 +46,13 @@ def keychain_get(service: str, account: str) -> str | None:
     return r.stdout.strip() if r.returncode == 0 else None
 
 def keychain_delete(service: str, account: str) -> None:
-    # Idempotent — succeeds silently if the entry doesn't exist
-    subprocess.run(
+    r = subprocess.run(
         ["security", "delete-generic-password", "-s", service, "-a", account],
         capture_output=True,
     )
+    # exit code 44 = item not found — treat as success (idempotent delete)
+    if r.returncode != 0 and r.returncode != 44:
+        raise RuntimeError(f"security delete-generic-password failed (exit {r.returncode})")
 ```
 
 **Linux** — `secret-tool` (freedesktop.org Secret Service):

--- a/skills/app-secret-management/references/keyring-by-framework.md
+++ b/skills/app-secret-management/references/keyring-by-framework.md
@@ -12,16 +12,20 @@ upgrades, venv rebuilds, `uv tool install`, `nvm use`, `rbenv` switches, etc.
 When the path changes, macOS prompts for re-authorization — once per keychain
 entry. This is a fundamental macOS security model constraint with no upstream fix.
 
-**Recommendation:** Use OS-native CLI tools via subprocess. These are always
-authorized (system-signed binaries with stable paths) and never trigger re-auth.
+**Recommendation:** Use OS-native CLI tools via subprocess. Their binary
+identity is stable (system-signed, fixed paths), so they avoid the
+re-authorization churn caused by interpreter path changes. (Other keychain
+prompts — locked keychain, new ACL decisions — can still occur.)
 
 **macOS** — `security` (Apple-signed, always in `/usr/bin/`):
 
-> **Note:** `-w` passes the password via process argv, which is briefly visible
-> to other processes (e.g., `ps`). This is the standard `security` CLI interface
-> and is generally accepted for CLI tools on macOS. For high-sensitivity secrets,
-> consider the encrypted store approach (single keychain entry) to minimize
-> exposure — see [runtime-storage-tradeoffs.md](runtime-storage-tradeoffs.md).
+> **Note:** `add-generic-password -w <password>` passes the secret via process
+> argv, which is briefly visible to other processes (e.g., `ps`). The `-w` flag
+> on `find-generic-password` only requests output and does not expose secrets in
+> argv. This is the standard `security` CLI interface and is generally accepted
+> for CLI tools on macOS. For high-sensitivity secrets, consider the encrypted
+> store approach (single keychain entry) to minimize exposure — see
+> [runtime-storage-tradeoffs.md](runtime-storage-tradeoffs.md).
 
 ```python
 import subprocess

--- a/skills/app-secret-management/references/keyring-by-framework.md
+++ b/skills/app-secret-management/references/keyring-by-framework.md
@@ -3,10 +3,85 @@
 Read this reference when implementing the keyring layer for a specific framework
 or app type.
 
-## CLI and Library-Based Apps
+## Interpreted-Language CLIs (Python, Node, Ruby, etc.)
 
-**Python:** `keyring` library (auto-detects backend: macOS Keychain, Windows
-Credential Locker, Linux Secret Service via D-Bus)
+**macOS binary-identity problem:** macOS Keychain ties access control to the
+binary that created each entry. Interpreted-language CLIs run through an
+interpreter binary (`python3`, `node`, `ruby`) whose path changes on version
+upgrades, venv rebuilds, `uv tool install`, `nvm use`, `rbenv` switches, etc.
+When the path changes, macOS prompts for re-authorization — once per keychain
+entry. This is a fundamental macOS security model constraint with no upstream fix.
+
+**Recommendation:** Use OS-native CLI tools via subprocess. These are always
+authorized (system-signed binaries with stable paths) and never trigger re-auth.
+
+**macOS** — `security` (Apple-signed, always in `/usr/bin/`):
+```python
+import subprocess, json
+
+def keychain_set(service: str, account: str, password: str) -> None:
+    # delete first to avoid "already exists" error on update
+    subprocess.run(
+        ["security", "delete-generic-password", "-s", service, "-a", account],
+        capture_output=True,  # ignore "not found" errors
+    )
+    subprocess.run(
+        ["security", "add-generic-password", "-s", service, "-a", account,
+         "-w", password, "-U"],
+        check=True,
+    )
+
+def keychain_get(service: str, account: str) -> str | None:
+    r = subprocess.run(
+        ["security", "find-generic-password", "-s", service, "-a", account, "-w"],
+        capture_output=True, text=True,
+    )
+    return r.stdout.strip() if r.returncode == 0 else None
+
+def keychain_delete(service: str, account: str) -> None:
+    subprocess.run(
+        ["security", "delete-generic-password", "-s", service, "-a", account],
+        check=True,
+    )
+```
+
+**Linux** — `secret-tool` (freedesktop.org Secret Service):
+```python
+import subprocess
+
+def keyring_set(service: str, account: str, password: str) -> None:
+    subprocess.run(
+        ["secret-tool", "store", "--label", f"{service}/{account}",
+         "service", service, "account", account],
+        input=password.encode(), check=True,
+    )
+
+def keyring_get(service: str, account: str) -> str | None:
+    r = subprocess.run(
+        ["secret-tool", "lookup", "service", service, "account", account],
+        capture_output=True, text=True,
+    )
+    return r.stdout.strip() if r.returncode == 0 else None
+
+def keyring_delete(service: str, account: str) -> None:
+    subprocess.run(
+        ["secret-tool", "clear", "service", service, "account", account],
+        check=True,
+    )
+```
+
+**Cross-platform wrapper:** Detect the platform at startup and dispatch to the
+appropriate functions above. For Windows (no binary-identity issue), the Python
+`keyring` library is fine.
+
+**Fallback — Python `keyring` library:** If OS CLI tools are unavailable, the
+`keyring` library works but be aware of the macOS binary-identity issue. Every
+Python binary path change (venv rebuild, version upgrade, `uv tool install`)
+will trigger one re-authorization prompt per keychain entry. This is tolerable
+for 1-2 secrets but painful at scale — see
+[runtime-storage-tradeoffs.md](runtime-storage-tradeoffs.md) for mitigation via
+encrypted store.
+
 ```python
 import keyring
 
@@ -14,6 +89,11 @@ keyring.set_password("myapp", key, value)    # store
 keyring.get_password("myapp", key)           # retrieve
 keyring.delete_password("myapp", key)        # remove
 ```
+
+## Compiled-Language CLIs (Go, Rust, etc.)
+
+Compiled binaries have stable identity — the binary IS the app — so
+library-based keyring access works without the binary-identity problem.
 
 **Rust:** `keyring` crate — maps `(service, user)` pairs to platform stores.
 **Go:** `zalando/go-keyring` — wraps macOS Keychain, Windows Credential Manager,
@@ -52,9 +132,6 @@ Security framework: `SecItemAdd`, `SecItemCopyMatching`, `SecItemUpdate`,
 Prefer the data protection keychain (`kSecUseDataProtectionKeychain`) over
 legacy file-based keychains — uses code signing entitlements instead of ACLs,
 eliminating user prompts for apps in the same access group.
-
-**Python on macOS:** `pyobjc-framework-Security` for direct bindings to
-`SecItemAdd`/`SecItemCopyMatching` without shelling out to `/usr/bin/security`.
 
 ## Native Windows
 

--- a/skills/app-secret-management/references/runtime-storage-tradeoffs.md
+++ b/skills/app-secret-management/references/runtime-storage-tradeoffs.md
@@ -56,10 +56,11 @@ local encrypted file. This makes encrypted store the safer default for
 interpreted-language CLIs with more than 2-3 secrets.
 
 Note: using OS CLI tools (`security` on macOS, `secret-tool` on Linux) instead
-of library-based keyring access avoids the binary-identity problem entirely —
-see [keyring-by-framework.md](keyring-by-framework.md). But minimizing keychain
-entries via encrypted store is still good defensive design for resilience against
-other ACL edge cases (code signing changes, keychain migrations).
+of library-based keyring access avoids the interpreter-binary re-authorization
+churn — see [keyring-by-framework.md](keyring-by-framework.md). But minimizing
+keychain entries via encrypted store is still good defensive design for
+resilience against other ACL edge cases (code signing changes, keychain
+migrations, locked keychain prompts).
 
 ## Encrypted Store Formats
 

--- a/skills/app-secret-management/references/runtime-storage-tradeoffs.md
+++ b/skills/app-secret-management/references/runtime-storage-tradeoffs.md
@@ -34,11 +34,32 @@ linked institution, per-user credentials in a multi-account app). Avoids
 keychain pollution, makes bulk export trivial, and is significantly faster for
 apps that read many secrets at startup.
 
-The tipping point is around 10 secrets. Below that, direct keyring is simpler
-and the overhead is negligible. Above that, keychain pollution and slow
-enumeration become real costs. Apps with dynamic/growing secret counts (e.g., one
-token per linked account) should use encrypted store from the start since the
-count is unbounded.
+The tipping point is around 10 secrets for compiled apps. Below that, direct
+keyring is simpler and the overhead is negligible. Above that, keychain
+pollution and slow enumeration become real costs. Apps with dynamic/growing
+secret counts (e.g., one token per linked account) should use encrypted store
+from the start since the count is unbounded.
+
+### Interpreted-language CLIs: lower tipping point
+
+For CLI apps written in Python, Node, Ruby, or other interpreted languages, the
+tipping point is lower — even a handful of direct keyring entries can be
+painful. On macOS, keychain ACLs are tied to the binary that accessed each
+entry. When the interpreter binary path changes (venv rebuild, version upgrade,
+`nvm use`, etc.), macOS prompts for re-authorization **once per keychain
+entry**. With direct keyring, this scales linearly with secret count: 3 secrets
+= 3 prompts, 22 secrets = 22 prompts.
+
+The encrypted store approach bounds this to a single re-authorization (for the
+one encryption key entry), regardless of how many secrets are stored in the
+local encrypted file. This makes encrypted store the safer default for
+interpreted-language CLIs with more than 2-3 secrets.
+
+Note: using OS CLI tools (`security` on macOS, `secret-tool` on Linux) instead
+of library-based keyring access avoids the binary-identity problem entirely —
+see [keyring-by-framework.md](keyring-by-framework.md). But minimizing keychain
+entries via encrypted store is still good defensive design for resilience against
+other ACL edge cases (code signing changes, keychain migrations).
 
 ## Encrypted Store Formats
 


### PR DESCRIPTION
## Summary
- Recommend OS CLI tools (`security` on macOS, `secret-tool` on Linux) as the primary keyring access method for interpreted-language CLIs (Python, Node, Ruby), replacing the `keyring` library recommendation
- On macOS, keychain ACLs are tied to the interpreter binary path — when it changes (venv rebuild, version upgrade, `nvm use`), every entry requires re-authorization. OS CLI tools have stable binary identity, avoiding this churn.
- Add binary-identity issue as a factor in runtime storage tradeoffs that lowers the encrypted-store tipping point for interpreted-language CLIs
- Demote Python `keyring` library to fallback with explicit warning; remove `pyobjc-framework-Security` recommendation
- Review fixes: removed unused import, simplified upsert logic (`-U` flag), documented argv exposure for `add-generic-password`, made delete idempotent (only suppresses not-found exit code 44), scoped absolute authorization claims

Closes #1

## Test plan
- [x] Skill files are valid markdown with correct frontmatter
- [x] Code examples in keyring-by-framework.md are syntactically correct Python
- [x] Cross-references between files resolve correctly (relative links)

🤖 Generated with [Claude Code](https://claude.ai/code)