### PR TITLE
feat: v4.0 — one keychain entry per app, encrypted store as default

### DIFF
--- a/skills/app-secret-management/SKILL.md
+++ b/skills/app-secret-management/SKILL.md
@@ -103,12 +103,13 @@ inaccessible — use one of these alternatives:
 The local secrets file is encrypted with the key from the single keychain entry.
 Format options:
 
-- **age-encrypted JSON** — simple, CLI-composable. Encrypt with `age`, decrypt
-  at startup using the keychain-stored key.
 - **Fernet (Python)** — symmetric encryption from the `cryptography` package.
-  Simple key management, no external tools needed.
+  No external tools needed. Recommended for Python CLIs.
+- **age-encrypted JSON** — CLI-composable, well-audited. Requires `age` CLI as
+  an external dependency. Better for shell scripts or non-Python tools.
 - **SOPS-encrypted YAML** — works well when secrets are mixed into config files.
   Only secret values are encrypted; keys and structure remain readable.
+  Requires `sops` and `age` as external dependencies.
 
 The encrypted file lives in the app's data directory (`~/.local/share/myapp/` on
 Linux, `~/Library/Application Support/myapp/` on macOS). Protect with filesystem

--- a/skills/app-secret-management/SKILL.md
+++ b/skills/app-secret-management/SKILL.md
@@ -12,64 +12,80 @@ description: >-
 license: MIT
 metadata:
   author: natecostello
-  version: "3.1"
+  version: "4.0"
 ---
 
 # App Secret Management
 
-System keyring for runtime, password manager for durable backup. This is the
-industry-standard approach used by `gh`, `aws`, `docker`, and VS Code — delegate
-to existing infrastructure rather than building custom encryption.
+One keychain entry per app, password manager for durable backup. Delegate to
+existing OS and password manager infrastructure rather than building custom
+encryption.
 
 Applies across app types (CLI, GUI, web app, daemon) — the keyring access method
 and nag mechanism vary by context.
 
 ## Core Principles
 
-1. **System keyring is the runtime store.** All secret reads come from the OS
-   keyring (macOS Keychain, GNOME Keyring, Windows Credential Manager).
+1. **One keychain entry per app.** Store a single encryption key in the OS
+   keychain. All secrets live in a local encrypted file, encrypted with that key.
+   This bounds ACL exposure to one entry — if it ever needs re-authorization,
+   it's one action, not one per secret.
 
-2. **Password manager is the durable backup.** On every secret mutation, auto-
-   export to the user's password manager. On a new machine, one import restores
-   everything.
+2. **OS CLI tools for interpreted languages.** Python, Node, Ruby CLIs access
+   the keychain via OS CLI tools (`security` on macOS, `secret-tool` on Linux),
+   not keyring libraries. OS CLI tools have stable binary identity
+   (system-signed, fixed paths). Keyring libraries go through the interpreter
+   binary, whose identity changes on upgrades, venv rebuilds, and reinstalls.
 
-3. **Never block the primary operation.** If the password manager is unavailable,
+3. **Password manager is the durable backup.** On every secret mutation,
+   auto-export the full secret set to the user's password manager. On a new
+   machine, one import restores everything.
+
+4. **Never block the primary operation.** If the password manager is unavailable,
    the keyring operation succeeds and the user gets a warning. Think `git commit`
    (always works offline) vs `git push` (durable backup, can fail gracefully).
 
-4. **Composability via stdin/stdout.** Export to stdout, import from stdin. Pipes
+5. **Composability via stdin/stdout.** Export to stdout, import from stdin. Pipes
    through any password manager CLI (`lpass`, `op`, `bw`) without the app knowing
    which one. See [keyring-by-framework.md](references/keyring-by-framework.md)
    for pipe examples.
 
 ## Architecture
 
-Runtime (keyring: direct or encrypted store) → auto-export → Password Manager (backup) → import on new machine
+```
+App startup:
+  1. Read encryption key from keychain (single OS keychain entry)
+  2. Decrypt local secrets file
+  3. Secrets available in memory
 
-**Two runtime approaches** — direct keyring (one entry per secret) or single
-keychain key + encrypted local store. Both are standard. Consult
-[runtime-storage-tradeoffs.md](references/runtime-storage-tradeoffs.md) when
-choosing between them.
+Secret mutation:
+  1. Update local encrypted file
+  2. Auto-export full secret set → password manager (fire-and-forget)
+
+New machine:
+  1. Import from password manager → local encrypted file + keychain entry
+```
 
 ## Implementation
 
 ### Keyring Layer
 
-Use the platform's keyring abstraction. Never store secrets in plaintext config
-files or databases. See
+One keychain entry holds the encryption key for the local secrets file. See
 [keyring-by-framework.md](references/keyring-by-framework.md) for per-framework
 code examples.
 
-**Interpreted-language CLIs (Python, Node, Ruby):** Prefer OS CLI tools
-(`security` on macOS, `secret-tool` on Linux) over library-based keyring access.
-On macOS, keychain ACLs are tied to the interpreter binary path — when it
-changes (venv rebuild, version upgrade, `nvm use`), every keychain entry
-requires re-authorization. OS CLI tools have stable binary identity
-(system-signed, fixed paths), avoiding this re-authorization churn. See the
-reference doc for code examples and fallback guidance.
+**Interpreted-language CLIs (Python, Node, Ruby):** Access the keychain via OS
+CLI tools (`security` on macOS, `secret-tool` on Linux). See the reference doc
+for code examples.
+
+**Compiled-language CLIs (Go, Rust):** Library-based keychain access is fine —
+compiled binaries have stable identity.
+
+**Electron:** Use the built-in `safeStorage` API, which implements this pattern
+natively (one keychain entry for encryption, encrypted buffers in local storage).
 
 **Daemons:** If the service runs in user context (LaunchAgent, systemd user
-service), keyring access works normally. If headless or root, the keyring may be
+service), keychain access works normally. If headless or root, the keyring may be
 inaccessible — use one of these alternatives:
 
 1. **SOPS + age** — encrypted config, decrypted at startup with a local identity
@@ -82,12 +98,28 @@ inaccessible — use one of these alternatives:
 4. **File-based keychain** (macOS) — dedicated `.keychain` file with password in
    System Keychain. More moving parts but works for true LaunchDaemons.
 
+### Encrypted Local Store
+
+The local secrets file is encrypted with the key from the single keychain entry.
+Format options:
+
+- **age-encrypted JSON** — simple, CLI-composable. Encrypt with `age`, decrypt
+  at startup using the keychain-stored key.
+- **Fernet (Python)** — symmetric encryption from the `cryptography` package.
+  Simple key management, no external tools needed.
+- **SOPS-encrypted YAML** — works well when secrets are mixed into config files.
+  Only secret values are encrypted; keys and structure remain readable.
+
+The encrypted file lives in the app's data directory (`~/.local/share/myapp/` on
+Linux, `~/Library/Application Support/myapp/` on macOS). Protect with filesystem
+permissions (chmod 600).
+
 ### Auto-Export on Mutation
 
 Every command that creates, updates, or deletes a secret triggers auto-export
-after the keyring operation succeeds. Auto-export serializes the app's **full
-secret set** as JSON (secret names as keys, values as strings) and writes it to
-the password manager item. This ensures the backup is always a complete snapshot.
+after the local encrypted file is updated. Auto-export serializes the app's
+**full secret set** and writes it to the password manager item. This ensures the
+backup is always a complete snapshot.
 
 Identify all mutation points: account linking, secret set/delete, migration from
 legacy storage, token refresh.
@@ -102,9 +134,8 @@ it fails, set a dirty flag and move on.
 ### Warn + Nag Pattern
 
 When auto-export fails, warn immediately but do not fail the operation. Record
-pending secrets in a dirty flag file in the platform's app data directory
-(`~/.local/share/myapp/` on Linux, `~/Library/Application Support/myapp/` on
-macOS, `%APPDATA%/myapp/` on Windows). On successful export, clear it.
+the failure in a dirty flag file in the app's data directory. On successful
+export, clear it.
 
 | App type | Warning | Persistent nag |
 |---|---|---|
@@ -136,32 +167,28 @@ Automate in a dotfile manager (chezmoi `run_once`) for unattended bootstrap.
 
 ## Checklist
 
-- [ ] All secret reads from system keyring or daemon alternative (see Keyring Layer)
-- [ ] Runtime storage approach chosen (see [tradeoffs reference](references/runtime-storage-tradeoffs.md))
+- [ ] Single keychain entry holds encryption key (not one entry per secret)
+- [ ] Local encrypted file stores all secrets
+- [ ] Interpreted-language CLI uses OS CLI tools for keychain access
 - [ ] Every mutation point triggers auto-export (fire-and-forget)
 - [ ] Export to stdout / import from stdin with `--include-secrets` safety gate
 - [ ] Failed export sets dirty flag; successful export clears it
 - [ ] Nag mechanism matches app type
 - [ ] Config supports `backup_backend: none`
-- [ ] Restore works end-to-end on a clean keyring
-- [ ] Daemon context verified: keyring accessible, or alternative tier chosen
+- [ ] Restore verified end-to-end on a clean keychain with real data
+- [ ] Daemon context verified: keychain accessible, or alternative tier chosen
 - [ ] CI disables auto-export (`backup_backend: none`)
-- [ ] Headless/CI: app falls back to env vars (e.g., `MYAPP_SECRET_<NAME>`) when keyring unavailable
+- [ ] Headless/CI: app falls back to env vars when keyring unavailable
 
 ## Edge Cases
 
 - **Multiple machines** — import should merge by default: match by secret name,
-  skip if same name already exists in keyring. `--force` for full overwrite.
+  skip if same name already exists. `--force` for full overwrite.
 - **Token refresh** — refreshed tokens are mutations; trigger auto-export.
 - **Bulk migration** — export once at the end, not once per secret.
 - **Keyring locked** — let the OS prompt for unlock. Daemons should fail clearly
   and fall back to cached values if available.
 - **Headless/CI** — `backup_backend: none`, read secrets from env vars
   (`MYAPP_SECRET_<NAME>`) or CI secrets manager when keyring is unavailable.
-- **macOS binary identity** — interpreted-language CLIs (Python, Node, Ruby)
-  should use OS CLI tools to avoid re-authorization prompts when the interpreter
-  binary path changes. See [keyring-by-framework.md](references/keyring-by-framework.md).
-  For native apps, data protection keychain requires signed binary with
-  entitlements. Test unsigned dev builds against legacy keychain.
 - **Bootstrap secret for daemon SDK** — service account token stored on disk has
   same trust model as age identity file. Protect with filesystem permissions.

--- a/skills/app-secret-management/SKILL.md
+++ b/skills/app-secret-management/SKILL.md
@@ -31,11 +31,12 @@ and nag mechanism vary by context.
    This bounds ACL exposure to one entry — if it ever needs re-authorization,
    it's one action, not one per secret.
 
-2. **OS CLI tools for interpreted languages.** Python, Node, Ruby CLIs access
-   the keychain via OS CLI tools (`security` on macOS, `secret-tool` on Linux),
-   not keyring libraries. OS CLI tools have stable binary identity
-   (system-signed, fixed paths). Keyring libraries go through the interpreter
-   binary, whose identity changes on upgrades, venv rebuilds, and reinstalls.
+2. **OS CLI tools for interpreted languages on macOS/Linux.** Python, Node,
+   Ruby CLIs on macOS/Linux access the keychain via OS CLI tools (`security`
+   on macOS, `secret-tool` on Linux), not keyring libraries. OS CLI tools have
+   stable binary identity (system-signed, fixed paths). Keyring libraries go
+   through the interpreter binary, whose identity changes on upgrades, venv
+   rebuilds, and reinstalls.
 
 3. **Password manager is the durable backup.** On every secret mutation,
    auto-export the full secret set to the user's password manager. On a new
@@ -107,7 +108,7 @@ Use the **age** encryption format — one standard across all languages:
 - **Non-Python CLIs / shell scripts:** `age` CLI
 - **Config files with mixed secrets:** SOPS + age (only values encrypted)
 
-See [runtime-storage-tradeoffs.md](references/runtime-storage-tradeoffs.md) for
+See [encrypted-store-implementation.md](references/encrypted-store-implementation.md) for
 code examples.
 
 The encrypted file lives in the app's data directory (`~/.local/share/myapp/` on

--- a/skills/app-secret-management/SKILL.md
+++ b/skills/app-secret-management/SKILL.md
@@ -101,15 +101,14 @@ inaccessible — use one of these alternatives:
 ### Encrypted Local Store
 
 The local secrets file is encrypted with the key from the single keychain entry.
-Format options:
+Use the **age** encryption format — one standard across all languages:
 
-- **Fernet (Python)** — symmetric encryption from the `cryptography` package.
-  No external tools needed. Recommended for Python CLIs.
-- **age-encrypted JSON** — CLI-composable, well-audited. Requires `age` CLI as
-  an external dependency. Better for shell scripts or non-Python tools.
-- **SOPS-encrypted YAML** — works well when secrets are mixed into config files.
-  Only secret values are encrypted; keys and structure remain readable.
-  Requires `sops` and `age` as external dependencies.
+- **Python:** `pyrage` library (Rust-backed, pre-built wheels, no CLI needed)
+- **Non-Python CLIs / shell scripts:** `age` CLI
+- **Config files with mixed secrets:** SOPS + age (only values encrypted)
+
+See [runtime-storage-tradeoffs.md](references/runtime-storage-tradeoffs.md) for
+code examples.
 
 The encrypted file lives in the app's data directory (`~/.local/share/myapp/` on
 Linux, `~/Library/Application Support/myapp/` on macOS). Protect with filesystem

--- a/skills/app-secret-management/references/encrypted-store-implementation.md
+++ b/skills/app-secret-management/references/encrypted-store-implementation.md
@@ -50,8 +50,14 @@ def decrypt_secrets(key: str, path: str) -> dict:
 
 ### Non-Python CLIs / shell scripts — `age` CLI
 
+> **Note:** Avoid passing the passphrase via `AGE_PASSPHRASE` in the
+> environment unless you have no better option — on many systems, environment
+> variables are visible to same-user processes and may be captured in crash
+> reports or logs. In practice the passphrase here is read from the keychain
+> into a short-lived variable, limiting exposure.
+
 ```bash
-# Encrypt
+# Encrypt ($KEY read from keychain, held in shell variable)
 echo '{"api_key": "sk-..."}' | AGE_PASSPHRASE="$KEY" age --encrypt --passphrase -o secrets.age
 
 # Decrypt
@@ -66,16 +72,15 @@ as a static binary.
 Only values are encrypted; keys and structure remain readable for debugging.
 
 ```bash
-sops --encrypt --age $(age-keygen -y key.txt) config.yaml > config.enc.yaml
-sops --decrypt config.enc.yaml
-```
+# After loading the age recipient/private key from the keychain into env vars:
+#   AGE_RECIPIENT=age1...
+#   SOPS_AGE_KEY=AGE-SECRET-KEY-...
 
-```bash
-# Encrypt (using age key stored in keychain)
-sops --encrypt --age $(age-keygen -y key.txt) config.yaml > config.enc.yaml
+# Encrypt
+sops --encrypt --age "$AGE_RECIPIENT" config.yaml > config.enc.yaml
 
 # Decrypt
-sops --decrypt config.enc.yaml
+SOPS_AGE_KEY="$SOPS_AGE_KEY" sops --decrypt config.enc.yaml
 ```
 
 ## File Location

--- a/skills/app-secret-management/references/keyring-by-framework.md
+++ b/skills/app-secret-management/references/keyring-by-framework.md
@@ -2,8 +2,8 @@
 
 Read this reference when implementing the keyring layer for a specific framework
 or app type. The app stores **one keychain entry** (the encryption key for a
-local encrypted secrets file) — see the main skill and
-[runtime-storage-tradeoffs.md](runtime-storage-tradeoffs.md) for details.
+local encrypted secrets file) — see the main skill and the
+[encrypted store implementation guide](encrypted-store-implementation.md) for implementation details.
 
 ## Interpreted-Language CLIs (Python, Node, Ruby, etc.)
 

--- a/skills/app-secret-management/references/keyring-by-framework.md
+++ b/skills/app-secret-management/references/keyring-by-framework.md
@@ -1,104 +1,85 @@
 # Keyring Access by Framework
 
 Read this reference when implementing the keyring layer for a specific framework
-or app type.
+or app type. The app stores **one keychain entry** (the encryption key for a
+local encrypted secrets file) — see the main skill and
+[runtime-storage-tradeoffs.md](runtime-storage-tradeoffs.md) for details.
 
 ## Interpreted-Language CLIs (Python, Node, Ruby, etc.)
 
-**macOS binary-identity problem:** macOS Keychain ties access control to the
-binary that created each entry. Interpreted-language CLIs run through an
-interpreter binary (`python3`, `node`, `ruby`) whose path changes on version
-upgrades, venv rebuilds, `uv tool install`, `nvm use`, `rbenv` switches, etc.
-When the path changes, macOS prompts for re-authorization — once per keychain
-entry. This is a fundamental macOS security model constraint with no upstream fix.
+Access the keychain via OS-native CLI tools. Their binary identity is stable
+(system-signed, fixed paths). Keyring libraries go through the interpreter
+binary, whose identity changes on upgrades, venv rebuilds, and reinstalls —
+each change requires manual re-authorization of the keychain entry.
 
-**Recommendation:** Use OS-native CLI tools via subprocess. Their binary
-identity is stable (system-signed, fixed paths), so they avoid the
-re-authorization churn caused by interpreter path changes. (Other keychain
-prompts — locked keychain, new ACL decisions — can still occur.)
-
-**macOS** — `security` (Apple-signed, always in `/usr/bin/`):
-
-> **Note:** `add-generic-password -w <password>` passes the secret via process
-> argv, which is briefly visible to other processes (e.g., `ps`). The `-w` flag
-> on `find-generic-password` only requests output and does not expose secrets in
-> argv. This is the standard `security` CLI interface and is generally accepted
-> for CLI tools on macOS. For high-sensitivity secrets, consider the encrypted
-> store approach (single keychain entry) to minimize exposure — see
-> [runtime-storage-tradeoffs.md](runtime-storage-tradeoffs.md).
+**macOS** — `security` (Apple-signed, `/usr/bin/security`):
 
 ```python
 import subprocess
 
-def keychain_set(service: str, account: str, password: str) -> None:
-    # -U updates the item if it already exists, or creates it if not
+SERVICE = "myapp"
+ACCOUNT = "encryption-key"
+
+def keychain_set(value: str) -> None:
     subprocess.run(
-        ["security", "add-generic-password", "-s", service, "-a", account,
-         "-w", password, "-U"],
+        ["security", "add-generic-password", "-s", SERVICE, "-a", ACCOUNT,
+         "-w", value, "-U"],
         check=True,
     )
 
-def keychain_get(service: str, account: str) -> str | None:
+def keychain_get() -> str | None:
     r = subprocess.run(
-        ["security", "find-generic-password", "-s", service, "-a", account, "-w"],
+        ["security", "find-generic-password", "-s", SERVICE, "-a", ACCOUNT, "-w"],
         capture_output=True, text=True,
     )
     return r.stdout.strip() if r.returncode == 0 else None
 
-def keychain_delete(service: str, account: str) -> None:
+def keychain_delete() -> None:
     r = subprocess.run(
-        ["security", "delete-generic-password", "-s", service, "-a", account],
+        ["security", "delete-generic-password", "-s", SERVICE, "-a", ACCOUNT],
         capture_output=True,
     )
-    # exit code 44 = item not found — treat as success (idempotent delete)
     if r.returncode != 0 and r.returncode != 44:
-        raise RuntimeError(f"security delete-generic-password failed (exit {r.returncode})")
+        raise RuntimeError(f"security delete failed (exit {r.returncode})")
 ```
 
+> **Note:** `add-generic-password -w <value>` passes the value via process
+> argv, briefly visible to other processes (e.g., `ps`). Since this is storing
+> an encryption key (not the actual secrets), the exposure is limited. This is
+> the standard `security` CLI interface.
+
 **Linux** — `secret-tool` (freedesktop.org Secret Service):
+
 ```python
 import subprocess
 
-def keyring_set(service: str, account: str, password: str) -> None:
+SERVICE = "myapp"
+ACCOUNT = "encryption-key"
+
+def keychain_set(value: str) -> None:
     subprocess.run(
-        ["secret-tool", "store", "--label", f"{service}/{account}",
-         "service", service, "account", account],
-        input=password.encode(), check=True,
+        ["secret-tool", "store", "--label", f"{SERVICE}/{ACCOUNT}",
+         "service", SERVICE, "account", ACCOUNT],
+        input=value.encode(), check=True,
     )
 
-def keyring_get(service: str, account: str) -> str | None:
+def keychain_get() -> str | None:
     r = subprocess.run(
-        ["secret-tool", "lookup", "service", service, "account", account],
+        ["secret-tool", "lookup", "service", SERVICE, "account", ACCOUNT],
         capture_output=True, text=True,
     )
     return r.stdout.strip() if r.returncode == 0 else None
 
-def keyring_delete(service: str, account: str) -> None:
+def keychain_delete() -> None:
     subprocess.run(
-        ["secret-tool", "clear", "service", service, "account", account],
+        ["secret-tool", "clear", "service", SERVICE, "account", ACCOUNT],
         check=True,
     )
 ```
 
 **Cross-platform wrapper:** Detect the platform at startup and dispatch to the
 appropriate functions above. For Windows (no binary-identity issue), the Python
-`keyring` library is fine.
-
-**Fallback — Python `keyring` library:** If OS CLI tools are unavailable, the
-`keyring` library works but be aware of the macOS binary-identity issue. Every
-Python binary path change (venv rebuild, version upgrade, `uv tool install`)
-will trigger one re-authorization prompt per keychain entry. This is tolerable
-for 1-2 secrets but painful at scale — see
-[runtime-storage-tradeoffs.md](runtime-storage-tradeoffs.md) for mitigation via
-encrypted store.
-
-```python
-import keyring
-
-keyring.set_password("myapp", key, value)    # store
-keyring.get_password("myapp", key)           # retrieve
-keyring.delete_password("myapp", key)        # remove
-```
+`keyring` library is fine for accessing the single encryption key entry.
 
 ## Compiled-Language CLIs (Go, Rust, etc.)
 
@@ -109,13 +90,15 @@ library-based keyring access works without the binary-identity problem.
 **Go:** `zalando/go-keyring` — wraps macOS Keychain, Windows Credential Manager,
 Linux D-Bus Secret Service.
 
-Use the app's name as the service name. Keep it consistent across all secrets.
+Use the app's name as the service name. One entry for the encryption key.
 
 ## Electron Apps
 
 Use the built-in `safeStorage` API (available since Electron v15; VS Code
-migrated from `keytar` to `safeStorage` in VS Code v1.80). Stores an
-encryption key in the OS keychain, returns encrypted buffers for local storage.
+migrated from `keytar` to `safeStorage` in VS Code v1.80). This implements the
+single-keychain-entry pattern natively — one keychain entry for encryption,
+encrypted buffers in local storage.
+
 ```javascript
 const { safeStorage } = require('electron');
 
@@ -154,6 +137,7 @@ logged-in user's credentials — no user interaction needed.
 ## Password Manager Pipe Examples
 
 Export/import composes with any password manager via stdin/stdout:
+
 ```bash
 # LastPass
 myapp secrets export --include-secrets | lpass edit --notes myapp/secrets
@@ -168,13 +152,6 @@ myapp secrets export --include-secrets | bw get item myapp/secrets | \
   jq --arg notes "$(cat)" '.notes = $notes' | bw edit item myapp/secrets
 bw get item myapp/secrets | jq -r '.notes' | myapp secrets import --force
 ```
-
-## Local Web Apps
-
-Call `keyring.get_password()` (or equivalent) at startup and hold secrets in
-memory. No interactive prompts are possible mid-request. The initial secret must
-have been stored by a process that could handle keychain ACL prompts (e.g., a
-CLI setup command or first-run wizard).
 
 ## Background Services and Daemons
 

--- a/skills/app-secret-management/references/runtime-storage-tradeoffs.md
+++ b/skills/app-secret-management/references/runtime-storage-tradeoffs.md
@@ -23,74 +23,52 @@ With one entry, re-authorization is one prompt. With twenty entries, it's twenty
 prompts. The encrypted store pattern makes this constant regardless of how many
 secrets the app manages.
 
-## Encrypted File Formats
+## Encryption Format: age
 
-### Fernet (recommended for Python CLIs)
+Use the **age** encryption format everywhere. One standard across all languages,
+interoperable files.
 
-Symmetric encryption from the `cryptography` package. No external tools
-required — pure Python dependency.
+### Python — `pyrage` library
+
+Rust-backed Python bindings for age. Pre-built wheels on PyPI — no Rust
+toolchain or external CLI needed.
 
 ```python
 import json
 from pathlib import Path
 
-from cryptography.fernet import Fernet
-
-def encrypt_secrets(secrets: dict, key: bytes, path: str) -> None:
-    f = Fernet(key)
-    plaintext = json.dumps(secrets).encode()
-    Path(path).write_bytes(f.encrypt(plaintext))
-
-def decrypt_secrets(key: bytes, path: str) -> dict:
-    f = Fernet(key)
-    ciphertext = Path(path).read_bytes()
-    return json.loads(f.decrypt(ciphertext))
-
-# Generate a new key (store this in keychain):
-# key = Fernet.generate_key()
-```
-
-### age-encrypted JSON
-
-Simple, CLI-composable, well-audited encryption. Requires `age` CLI as an
-external dependency (`brew install age` on macOS, package managers on Linux).
-Better suited for shell scripts or non-Python tools where `cryptography`
-isn't available.
-
-```python
-import json
-import os
-import subprocess
-from pathlib import Path
+from pyrage import passphrase
 
 def encrypt_secrets(secrets: dict, key: str, path: str) -> None:
-    """Encrypt secrets dict to file using age."""
-    plaintext = json.dumps(secrets, indent=2)
-    result = subprocess.run(
-        ["age", "--encrypt", "--passphrase", "-o", path],
-        input=plaintext, text=True, capture_output=True,
-        env={**os.environ, "AGE_PASSPHRASE": key},
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"age encrypt failed: {result.stderr}")
+    plaintext = json.dumps(secrets).encode()
+    Path(path).write_bytes(passphrase.encrypt(plaintext, key))
 
 def decrypt_secrets(key: str, path: str) -> dict:
-    """Decrypt secrets file using age."""
-    result = subprocess.run(
-        ["age", "--decrypt", path],
-        capture_output=True, text=True,
-        env={**os.environ, "AGE_PASSPHRASE": key},
-    )
-    if result.returncode != 0:
-        raise RuntimeError(f"age decrypt failed: {result.stderr}")
-    return json.loads(result.stdout)
+    ciphertext = Path(path).read_bytes()
+    return json.loads(passphrase.decrypt(ciphertext, key))
 ```
 
-### SOPS-encrypted YAML
+### Non-Python CLIs / shell scripts — `age` CLI
 
-Best when secrets are mixed into config files. Only values are encrypted;
-keys and structure remain readable for debugging. Requires `sops` and `age`
-as external dependencies.
+```bash
+# Encrypt
+echo '{"api_key": "sk-..."}' | AGE_PASSPHRASE="$KEY" age --encrypt --passphrase -o secrets.age
+
+# Decrypt
+AGE_PASSPHRASE="$KEY" age --decrypt secrets.age
+```
+
+Available via Homebrew (`brew install age`), most Linux package managers, and
+as a static binary.
+
+### Config files with mixed secrets — SOPS + age
+
+Only values are encrypted; keys and structure remain readable for debugging.
+
+```bash
+sops --encrypt --age $(age-keygen -y key.txt) config.yaml > config.enc.yaml
+sops --decrypt config.enc.yaml
+```
 
 ```bash
 # Encrypt (using age key stored in keychain)

--- a/skills/app-secret-management/references/runtime-storage-tradeoffs.md
+++ b/skills/app-secret-management/references/runtime-storage-tradeoffs.md
@@ -25,9 +25,37 @@ secrets the app manages.
 
 ## Encrypted File Formats
 
-### age-encrypted JSON (recommended for CLIs)
+### Fernet (recommended for Python CLIs)
 
-Simple, CLI-composable, well-audited encryption.
+Symmetric encryption from the `cryptography` package. No external tools
+required — pure Python dependency.
+
+```python
+import json
+from pathlib import Path
+
+from cryptography.fernet import Fernet
+
+def encrypt_secrets(secrets: dict, key: bytes, path: str) -> None:
+    f = Fernet(key)
+    plaintext = json.dumps(secrets).encode()
+    Path(path).write_bytes(f.encrypt(plaintext))
+
+def decrypt_secrets(key: bytes, path: str) -> dict:
+    f = Fernet(key)
+    ciphertext = Path(path).read_bytes()
+    return json.loads(f.decrypt(ciphertext))
+
+# Generate a new key (store this in keychain):
+# key = Fernet.generate_key()
+```
+
+### age-encrypted JSON
+
+Simple, CLI-composable, well-audited encryption. Requires `age` CLI as an
+external dependency (`brew install age` on macOS, package managers on Linux).
+Better suited for shell scripts or non-Python tools where `cryptography`
+isn't available.
 
 ```python
 import json
@@ -58,38 +86,11 @@ def decrypt_secrets(key: str, path: str) -> dict:
     return json.loads(result.stdout)
 ```
 
-Requires `age` CLI installed. Available via Homebrew (`brew install age`),
-most Linux package managers, and as a static binary.
-
-### Fernet (Python, no external tools)
-
-Symmetric encryption from the `cryptography` package. Good when you don't
-want to require `age` as a dependency.
-
-```python
-import json
-from pathlib import Path
-
-from cryptography.fernet import Fernet
-
-def encrypt_secrets(secrets: dict, key: bytes, path: str) -> None:
-    f = Fernet(key)
-    plaintext = json.dumps(secrets).encode()
-    Path(path).write_bytes(f.encrypt(plaintext))
-
-def decrypt_secrets(key: bytes, path: str) -> dict:
-    f = Fernet(key)
-    ciphertext = Path(path).read_bytes()
-    return json.loads(f.decrypt(ciphertext))
-
-# Generate a new key (store this in keychain):
-# key = Fernet.generate_key()
-```
-
 ### SOPS-encrypted YAML
 
 Best when secrets are mixed into config files. Only values are encrypted;
-keys and structure remain readable for debugging.
+keys and structure remain readable for debugging. Requires `sops` and `age`
+as external dependencies.
 
 ```bash
 # Encrypt (using age key stored in keychain)

--- a/skills/app-secret-management/references/runtime-storage-tradeoffs.md
+++ b/skills/app-secret-management/references/runtime-storage-tradeoffs.md
@@ -1,84 +1,131 @@
-# Runtime Storage: Direct Keyring vs. Encrypted Store
+# Encrypted Store Implementation
 
-Read this reference when deciding how secrets are stored at runtime. Both
-approaches are standard; the right one depends on the application.
+Read this reference when implementing the encrypted local store — the single
+keychain entry + local encrypted file pattern.
 
-## The Two Approaches
+## How It Works
 
-**Direct keyring** — one keychain entry per secret. `gh` and `docker` use this.
+One keychain entry holds an encryption key. All app secrets live in a local
+encrypted file, encrypted with that key. At startup, the app reads the key from
+the keychain, decrypts the file, and holds secrets in memory.
 
-**Single key + encrypted store** — one keychain entry holds an encryption key,
-all secrets live in a local encrypted file or database. VS Code and Electron
-apps use this (via `safeStorage`).
+This is the same pattern VS Code uses (via Electron `safeStorage`): one keychain
+entry for encryption, encrypted buffers in local storage.
 
-## Comparison
+## Why One Entry
 
-| | Direct keyring | Single key + encrypted store |
-|---|---|---|
-| Implementation | Simple — just call keyring API | Extra layer: encrypt/decrypt + local file |
-| Secret count | Best for small, stable sets (under ~10) | Better for large or growing sets (10+) |
-| Bulk operations | Slow — one keychain call per secret | Fast — one unlock, then local I/O |
-| Backup/export | Must enumerate keychain entries | Copy one file (or serialize one object) |
-| Per-secret ACL | OS manages access per item | Single ACL on the encryption key |
-| Failure blast radius | Lose one entry, lose one secret | Corrupt file, lose all secrets |
-| Keychain pollution | One entry per secret in user's keychain | One entry total |
+Each keychain entry is an independent ACL. On macOS, keychain ACLs are tied to
+the binary that accessed the entry. If the binary changes (interpreter upgrade,
+venv rebuild, app reinstall), every entry requires manual re-authorization —
+one password prompt per entry, each requiring the user's login password.
 
-## When to Use Which
+With one entry, re-authorization is one prompt. With twenty entries, it's twenty
+prompts. The encrypted store pattern makes this constant regardless of how many
+secrets the app manages.
 
-**Direct keyring** when the secret count is small and predictable (a handful of
-API keys, a fixed set of service credentials). Simpler to implement, no file
-format to maintain, and per-secret OS access control is a benefit.
+## Encrypted File Formats
 
-**Encrypted store** when secrets are numerous or grow dynamically (one token per
-linked institution, per-user credentials in a multi-account app). Avoids
-keychain pollution, makes bulk export trivial, and is significantly faster for
-apps that read many secrets at startup.
+### age-encrypted JSON (recommended for CLIs)
 
-The tipping point is around 10 secrets for compiled apps. Below that, direct
-keyring is simpler and the overhead is negligible. Above that, keychain
-pollution and slow enumeration become real costs. Apps with dynamic/growing
-secret counts (e.g., one token per linked account) should use encrypted store
-from the start since the count is unbounded.
+Simple, CLI-composable, well-audited encryption.
 
-### Interpreted-language CLIs: lower tipping point
+```python
+import json
+import os
+import subprocess
+from pathlib import Path
 
-For CLI apps written in Python, Node, Ruby, or other interpreted languages, the
-tipping point is lower — even a handful of direct keyring entries can be
-painful. On macOS, keychain ACLs are tied to the binary that accessed each
-entry. When the interpreter binary path changes (venv rebuild, version upgrade,
-`nvm use`, etc.), macOS prompts for re-authorization **once per keychain
-entry**. With direct keyring, this scales linearly with secret count: 3 secrets
-= 3 prompts, 22 secrets = 22 prompts.
+def encrypt_secrets(secrets: dict, key: str, path: str) -> None:
+    """Encrypt secrets dict to file using age."""
+    plaintext = json.dumps(secrets, indent=2)
+    result = subprocess.run(
+        ["age", "--encrypt", "--passphrase", "-o", path],
+        input=plaintext, text=True, capture_output=True,
+        env={**os.environ, "AGE_PASSPHRASE": key},
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"age encrypt failed: {result.stderr}")
 
-The encrypted store approach bounds this to a single re-authorization (for the
-one encryption key entry), regardless of how many secrets are stored in the
-local encrypted file. This makes encrypted store the safer default for
-interpreted-language CLIs with more than 2-3 secrets.
+def decrypt_secrets(key: str, path: str) -> dict:
+    """Decrypt secrets file using age."""
+    result = subprocess.run(
+        ["age", "--decrypt", path],
+        capture_output=True, text=True,
+        env={**os.environ, "AGE_PASSPHRASE": key},
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"age decrypt failed: {result.stderr}")
+    return json.loads(result.stdout)
+```
 
-Note: using OS CLI tools (`security` on macOS, `secret-tool` on Linux) instead
-of library-based keyring access avoids the interpreter-binary re-authorization
-churn — see [keyring-by-framework.md](keyring-by-framework.md). But minimizing
-keychain entries via encrypted store is still good defensive design for
-resilience against other ACL edge cases (code signing changes, keychain
-migrations, locked keychain prompts).
+Requires `age` CLI installed. Available via Homebrew (`brew install age`),
+most Linux package managers, and as a static binary.
 
-## Encrypted Store Formats
+### Fernet (Python, no external tools)
 
-- **age-encrypted JSON** — simple, CLI-composable. Encrypt with `age`, decrypt
-  at startup using keychain-stored key or age identity file.
-- **SQLite + safeStorage buffers** — Electron's approach. `safeStorage` encrypts
-  each value, store the buffers in SQLite.
-- **SOPS-encrypted YAML** — works well when secrets are mixed into config files.
-  Only secret values are encrypted; keys and structure remain readable.
+Symmetric encryption from the `cryptography` package. Good when you don't
+want to require `age` as a dependency.
 
-## Encrypted Store vs. Encrypted Backup — Not the Same Thing
+```python
+import json
+from pathlib import Path
 
-The encrypted store pattern is the **runtime** layer — the encryption key lives
-in the keychain, secrets live in a local file. The password manager is still the
-durable backup. Don't confuse this with using an encrypted file as a backup tier
-alongside a password manager — that creates two sources of truth with sync
-conflicts. Only use built-in encryption as the backup tier if no password manager
-is available (CI, containers).
+from cryptography.fernet import Fernet
 
-Both runtime approaches feed into the same password manager backup tier — this
-choice only affects local storage.
+def encrypt_secrets(secrets: dict, key: bytes, path: str) -> None:
+    f = Fernet(key)
+    plaintext = json.dumps(secrets).encode()
+    Path(path).write_bytes(f.encrypt(plaintext))
+
+def decrypt_secrets(key: bytes, path: str) -> dict:
+    f = Fernet(key)
+    ciphertext = Path(path).read_bytes()
+    return json.loads(f.decrypt(ciphertext))
+
+# Generate a new key (store this in keychain):
+# key = Fernet.generate_key()
+```
+
+### SOPS-encrypted YAML
+
+Best when secrets are mixed into config files. Only values are encrypted;
+keys and structure remain readable for debugging.
+
+```bash
+# Encrypt (using age key stored in keychain)
+sops --encrypt --age $(age-keygen -y key.txt) config.yaml > config.enc.yaml
+
+# Decrypt
+sops --decrypt config.enc.yaml
+```
+
+## File Location
+
+Store the encrypted file in the app's data directory:
+
+| Platform | Path |
+|---|---|
+| macOS | `~/Library/Application Support/myapp/secrets.age` |
+| Linux | `~/.local/share/myapp/secrets.age` |
+| Windows | `%APPDATA%/myapp/secrets.age` |
+
+Protect with filesystem permissions (chmod 600 on Unix).
+
+## Key Rotation
+
+To rotate the encryption key:
+
+1. Decrypt with old key
+2. Generate new key
+3. Re-encrypt with new key
+4. Store new key in keychain (overwrites old)
+5. Trigger auto-export (backup the new state)
+
+This is a single keychain write — no ACL concerns.
+
+## Encrypted Store vs. Encrypted Backup
+
+The encrypted store is the **runtime** layer — the encryption key lives in the
+keychain, secrets live in a local file. The password manager is the **durable
+backup**. Don't use an encrypted file as a backup tier alongside a password
+manager — that creates two sources of truth with sync conflicts.


### PR DESCRIPTION
## Summary
- Single keychain entry per app (encrypted store pattern) is now the only prescribed approach
- OS CLI tools for interpreted languages is a hard rule, not a preference
- Removed "direct keyring" as an option — no more N entries with N independent ACLs
- Renamed tradeoffs doc to encrypted store implementation guide
- Updated framework reference to show single-entry examples

## Why
Real-world incident: 22 keychain entries with broken ACLs after a Python binary change. No reliable programmatic batch-fix exists on modern macOS (`set-generic-password-partition-list` doesn't work). Recovery required manual re-authorization per entry. With one keychain entry, this is one click instead of twenty-two.

Closes #1

🤖 Generated with [Claude Code](https://claude.ai/code)