### PR TITLE
fix: recommend age identity keys over passphrase mode

### DIFF
--- a/skills/app-secret-management/SKILL.md
+++ b/skills/app-secret-management/SKILL.md
@@ -12,7 +12,7 @@ description: >-
 license: MIT
 metadata:
   author: natecostello
-  version: "4.0"
+  version: "4.1"
 ---
 
 # App Secret Management
@@ -26,10 +26,10 @@ and nag mechanism vary by context.
 
 ## Core Principles
 
-1. **One keychain entry per app.** Store a single encryption key in the OS
-   keychain. All secrets live in a local encrypted file, encrypted with that key.
-   This bounds ACL exposure to one entry — if it ever needs re-authorization,
-   it's one action, not one per secret.
+1. **One keychain entry per app.** Store a single age identity key in the OS
+   keychain. All secrets live in a local encrypted file, encrypted to that
+   identity's public recipient. This bounds ACL exposure to one entry — if it
+   ever needs re-authorization, it's one action, not one per secret.
 
 2. **OS CLI tools for interpreted languages on macOS/Linux.** Python, Node,
    Ruby CLIs on macOS/Linux access the keychain via OS CLI tools (`security`
@@ -55,7 +55,7 @@ and nag mechanism vary by context.
 
 ```
 App startup:
-  1. Read encryption key from keychain (single OS keychain entry)
+  1. Read age identity key from keychain (single OS keychain entry)
   2. Decrypt local secrets file
   3. Secrets available in memory
 
@@ -71,7 +71,7 @@ New machine:
 
 ### Keyring Layer
 
-One keychain entry holds the encryption key for the local secrets file. See
+One keychain entry holds the age identity key for the local secrets file. See
 [keyring-by-framework.md](references/keyring-by-framework.md) for per-framework
 code examples.
 
@@ -101,12 +101,16 @@ inaccessible — use one of these alternatives:
 
 ### Encrypted Local Store
 
-The local secrets file is encrypted with the key from the single keychain entry.
-Use the **age** encryption format — one standard across all languages:
+The local secrets file is encrypted with the age identity key from the single
+keychain entry. Use the **age** encryption format with **identity keys** (not
+passphrase mode) — one standard across all languages:
 
 - **Python:** `pyrage` library (Rust-backed, pre-built wheels, no CLI needed)
 - **Non-Python CLIs / shell scripts:** `age` CLI
 - **Config files with mixed secrets:** SOPS + age (only values encrypted)
+
+Identity key mode (X25519) decrypts instantly. Passphrase mode runs scrypt
+(~1 s per decrypt) — wasted when the keychain already holds a high-entropy key.
 
 See [encrypted-store-implementation.md](references/encrypted-store-implementation.md) for
 code examples.
@@ -168,7 +172,7 @@ Automate in a dotfile manager (chezmoi `run_once`) for unattended bootstrap.
 
 ## Checklist
 
-- [ ] Single keychain entry holds encryption key (not one entry per secret)
+- [ ] Single keychain entry holds age identity key (not one entry per secret)
 - [ ] Local encrypted file stores all secrets
 - [ ] Interpreted-language CLI uses OS CLI tools for keychain access
 - [ ] Every mutation point triggers auto-export (fire-and-forget)

--- a/skills/app-secret-management/references/encrypted-store-implementation.md
+++ b/skills/app-secret-management/references/encrypted-store-implementation.md
@@ -5,9 +5,10 @@ keychain entry + local encrypted file pattern.
 
 ## How It Works
 
-One keychain entry holds an encryption key. All app secrets live in a local
-encrypted file, encrypted with that key. At startup, the app reads the key from
-the keychain, decrypts the file, and holds secrets in memory.
+One keychain entry holds an age identity key (`AGE-SECRET-KEY-1...`). All app
+secrets live in a local encrypted file, encrypted to that identity's public
+recipient. At startup, the app reads the identity key from the keychain,
+decrypts the file, and holds secrets in memory.
 
 This is the same pattern VS Code uses (via Electron `safeStorage`): one keychain
 entry for encryption, encrypted buffers in local storage.
@@ -28,6 +29,17 @@ secrets the app manages.
 Use the **age** encryption format everywhere. One standard across all languages,
 interoperable files.
 
+**Use identity keys, not passphrase mode.** Age passphrase mode runs scrypt (a
+deliberately slow KDF) on every decrypt — roughly 1 second with age's default
+parameters, which are fixed in the spec and not tunable. Since the keychain
+already stores a high-entropy machine-generated key, scrypt's brute-force
+protection is wasted. Identity key mode uses X25519 key agreement + symmetric
+decrypt, which is effectively instant.
+
+The keychain stores the identity key string (a single ~74-character
+`AGE-SECRET-KEY-1...` value). The public recipient needed for encryption is
+derived on the fly from the identity — no separate key to manage.
+
 ### Python — `pyrage` library
 
 Rust-backed Python bindings for age. Pre-built wheels on PyPI — no Rust
@@ -37,31 +49,41 @@ toolchain or external CLI needed.
 import json
 from pathlib import Path
 
-from pyrage import passphrase
+import pyrage
+from pyrage import x25519
 
-def encrypt_secrets(secrets: dict, key: str, path: str) -> None:
+def generate_identity() -> str:
+    """Generate a new age identity key. Store the returned string in the keychain."""
+    return str(x25519.Identity.generate())
+
+def encrypt_secrets(secrets: dict, identity_str: str, path: str) -> None:
+    identity = x25519.Identity.from_str(identity_str)
+    recipient = identity.to_public()
     plaintext = json.dumps(secrets).encode()
-    Path(path).write_bytes(passphrase.encrypt(plaintext, key))
+    Path(path).write_bytes(pyrage.encrypt(plaintext, [recipient]))
 
-def decrypt_secrets(key: str, path: str) -> dict:
+def decrypt_secrets(identity_str: str, path: str) -> dict:
+    identity = x25519.Identity.from_str(identity_str)
     ciphertext = Path(path).read_bytes()
-    return json.loads(passphrase.decrypt(ciphertext, key))
+    return json.loads(pyrage.decrypt(ciphertext, [identity]))
 ```
 
 ### Non-Python CLIs / shell scripts — `age` CLI
 
-> **Note:** Avoid passing the passphrase via `AGE_PASSPHRASE` in the
-> environment unless you have no better option — on many systems, environment
-> variables are visible to same-user processes and may be captured in crash
-> reports or logs. In practice the passphrase here is read from the keychain
-> into a short-lived variable, limiting exposure.
+The keychain stores the age identity key (`AGE-SECRET-KEY-1...`). Write it to a
+temporary file for the `age` CLI, or pipe it via process substitution.
 
 ```bash
-# Encrypt ($KEY read from keychain, held in shell variable)
-echo '{"api_key": "sk-..."}' | AGE_PASSPHRASE="$KEY" age --encrypt --passphrase -o secrets.age
+# Generate identity (once, during first-run setup)
+age-keygen 2>/dev/null  # outputs AGE-SECRET-KEY-1... to stdout
+# Store the secret key line in the keychain; derive the recipient:
+RECIPIENT=$(echo "$IDENTITY_KEY" | age-keygen -y)
 
-# Decrypt
-AGE_PASSPHRASE="$KEY" age --decrypt secrets.age
+# Encrypt
+echo '{"api_key": "sk-..."}' | age --encrypt --recipient "$RECIPIENT" -o secrets.age
+
+# Decrypt (pipe identity via process substitution — no temp file on disk)
+age --decrypt --identity <(echo "$IDENTITY_KEY") secrets.age
 ```
 
 Available via Homebrew (`brew install age`), most Linux package managers, and
@@ -72,15 +94,15 @@ as a static binary.
 Only values are encrypted; keys and structure remain readable for debugging.
 
 ```bash
-# After loading the age recipient/private key from the keychain into env vars:
-#   AGE_RECIPIENT=age1...
-#   SOPS_AGE_KEY=AGE-SECRET-KEY-...
+# After loading the age identity key from the keychain:
+#   IDENTITY_KEY=AGE-SECRET-KEY-1...
+RECIPIENT=$(echo "$IDENTITY_KEY" | age-keygen -y)
 
 # Encrypt
-sops --encrypt --age "$AGE_RECIPIENT" config.yaml > config.enc.yaml
+sops --encrypt --age "$RECIPIENT" config.yaml > config.enc.yaml
 
 # Decrypt
-SOPS_AGE_KEY="$SOPS_AGE_KEY" sops --decrypt config.enc.yaml
+SOPS_AGE_KEY="$IDENTITY_KEY" sops --decrypt config.enc.yaml
 ```
 
 ## File Location
@@ -97,12 +119,12 @@ Protect with filesystem permissions (chmod 600 on Unix).
 
 ## Key Rotation
 
-To rotate the encryption key:
+To rotate the identity key:
 
-1. Decrypt with old key
-2. Generate new key
-3. Re-encrypt with new key
-4. Store new key in keychain (overwrites old)
+1. Decrypt with old identity
+2. Generate new identity (`x25519.Identity.generate()` / `age-keygen`)
+3. Re-encrypt with new identity's public recipient
+4. Store new identity key string in keychain (overwrites old)
 5. Trigger auto-export (backup the new state)
 
 This is a single keychain write — no ACL concerns.

--- a/skills/app-secret-management/references/encrypted-store-implementation.md
+++ b/skills/app-secret-management/references/encrypted-store-implementation.md
@@ -36,7 +36,7 @@ already stores a high-entropy machine-generated key, scrypt's brute-force
 protection is wasted. Identity key mode uses X25519 key agreement + symmetric
 decrypt, which is effectively instant.
 
-The keychain stores the identity key string (a single ~74-character
+The keychain stores the identity key string (a single 74-character
 `AGE-SECRET-KEY-1...` value). The public recipient needed for encryption is
 derived on the fly from the identity — no separate key to manage.
 
@@ -70,21 +70,26 @@ def decrypt_secrets(identity_str: str, path: str) -> dict:
 
 ### Non-Python CLIs / shell scripts — `age` CLI
 
-The keychain stores the age identity key (`AGE-SECRET-KEY-1...`). Write it to a
-temporary file for the `age` CLI, or pipe it via process substitution.
+The keychain stores the age identity key (`AGE-SECRET-KEY-1...`). Pipe it to
+the `age` CLI via process substitution — `echo` is a shell builtin, so the key
+never appears in `ps` output.
 
 ```bash
 # Generate identity (once, during first-run setup)
-age-keygen 2>/dev/null  # outputs AGE-SECRET-KEY-1... to stdout
+age-keygen 2>/dev/null | grep "^AGE-SECRET-KEY-"  # extract only the key line
 # Store the secret key line in the keychain; derive the recipient:
 RECIPIENT=$(echo "$IDENTITY_KEY" | age-keygen -y)
 
 # Encrypt
 echo '{"api_key": "sk-..."}' | age --encrypt --recipient "$RECIPIENT" -o secrets.age
 
-# Decrypt (pipe identity via process substitution — no temp file on disk)
+# Decrypt (process substitution — no temp file on disk)
 age --decrypt --identity <(echo "$IDENTITY_KEY") secrets.age
 ```
+
+> **Note:** Process substitution (`<(...)`) requires bash/zsh. In POSIX sh or
+> dash, write the identity to a temporary file (mode 600), decrypt, then remove
+> it.
 
 Available via Homebrew (`brew install age`), most Linux package managers, and
 as a static binary.
@@ -131,7 +136,7 @@ This is a single keychain write — no ACL concerns.
 
 ## Encrypted Store vs. Encrypted Backup
 
-The encrypted store is the **runtime** layer — the encryption key lives in the
+The encrypted store is the **runtime** layer — the identity key lives in the
 keychain, secrets live in a local file. The password manager is the **durable
 backup**. Don't use an encrypted file as a backup tier alongside a password
 manager — that creates two sources of truth with sync conflicts.

--- a/skills/app-secret-management/references/keyring-by-framework.md
+++ b/skills/app-secret-management/references/keyring-by-framework.md
@@ -1,7 +1,7 @@
 # Keyring Access by Framework
 
 Read this reference when implementing the keyring layer for a specific framework
-or app type. The app stores **one keychain entry** (the encryption key for a
+or app type. The app stores **one keychain entry** (the age identity key for a
 local encrypted secrets file) — see the main skill and the
 [encrypted store implementation guide](encrypted-store-implementation.md) for implementation details.
 
@@ -18,7 +18,7 @@ each change requires manual re-authorization of the keychain entry.
 import subprocess
 
 SERVICE = "myapp"
-ACCOUNT = "encryption-key"
+ACCOUNT = "identity-key"
 
 def keychain_set(value: str) -> None:
     subprocess.run(
@@ -45,7 +45,7 @@ def keychain_delete() -> None:
 
 > **Note:** `add-generic-password -w <value>` passes the value via process
 > argv, briefly visible to other processes (e.g., `ps`). Since this is storing
-> an encryption key (not the actual secrets), the exposure is limited. This is
+> an age identity key (not the actual secrets), the exposure is limited. This is
 > the standard `security` CLI interface.
 
 **Linux** — `secret-tool` (freedesktop.org Secret Service):
@@ -54,7 +54,7 @@ def keychain_delete() -> None:
 import subprocess
 
 SERVICE = "myapp"
-ACCOUNT = "encryption-key"
+ACCOUNT = "identity-key"
 
 def keychain_set(value: str) -> None:
     subprocess.run(
@@ -90,7 +90,7 @@ library-based keyring access works without the binary-identity problem.
 **Go:** `zalando/go-keyring` — wraps macOS Keychain, Windows Credential Manager,
 Linux D-Bus Secret Service.
 
-Use the app's name as the service name. One entry for the encryption key.
+Use the app's name as the service name. One entry for the age identity key.
 
 ## Electron Apps
 

--- a/skills/app-secret-management/references/keyring-by-framework.md
+++ b/skills/app-secret-management/references/keyring-by-framework.md
@@ -79,7 +79,7 @@ def keychain_delete() -> None:
 
 **Cross-platform wrapper:** Detect the platform at startup and dispatch to the
 appropriate functions above. For Windows (no binary-identity issue), the Python
-`keyring` library is fine for accessing the single encryption key entry.
+`keyring` library is fine for accessing the single identity key entry.
 
 ## Compiled-Language CLIs (Go, Rust, etc.)
 


### PR DESCRIPTION
## Summary
- Replaces age passphrase mode with identity key mode (`pyrage.x25519.Identity`) across all skill docs
- Passphrase mode runs scrypt (~1s per decrypt), wasted when the keychain holds a high-entropy key; identity keys decrypt instantly via X25519
- Updates Python examples, shell examples, SOPS examples, and aligns terminology (encryption key → identity key) throughout

Closes #4

## Plan compliance
- [x] Add guidance to "Encrypted Local Store" section recommending identity keys — DONE (SKILL.md + encrypted-store-implementation.md)
- [x] Replace `pyrage.passphrase` Python example with `pyrage.x25519.Identity` — DONE
- [x] Replace shell passphrase examples with `--recipient`/`--identity` flags — DONE
- [x] Update SOPS example to derive recipient from identity — DONE
- [x] Align terminology across all three docs — DONE

## Test plan
- [ ] Read through SKILL.md, encrypted-store-implementation.md, and keyring-by-framework.md for consistency
- [ ] Verify Python code example imports are correct (`import pyrage` + `from pyrage import x25519`)
- [ ] Verify shell examples use `age-keygen -y` for recipient derivation and `--identity` for decrypt

🤖 Generated with [Claude Code](https://claude.com/claude-code)