### PR TITLE
Fix audit-repo cancellation mechanism

### DIFF
--- a/skills/audit-repo/SKILL.md
+++ b/skills/audit-repo/SKILL.md
@@ -222,9 +222,9 @@ Append to {audit_dir}/log.md:
 "YYYY-MM-DD HH:MM — PR #N: BLOCK: <description> (issue #M created)"
 
 After creating the blocking issue and appending to the log, cancel the
-audit loop immediately: run `CronList` to find the job id, then
-`CronDelete <job-id>`. (For a self-pacing dynamic loop, omit the next
-`ScheduleWakeup` call instead.)
+audit loop immediately: run `CronList` to find this loop's job id
+(match by the prompt or schedule you started with), then
+`CronDelete <job-id>`.
 
 ### Bright Lines (block immediately)
 - Projected steady-state cost exceeds $25/mo
@@ -336,6 +336,7 @@ WARN with a GitHub issue.
 
 The audit loop runs until:
 - You stop it manually (Ctrl-C or close the session)
-- You cancel the scheduled job via `CronDelete <job-id>` (or, for a
-  self-pacing dynamic loop, by omitting the next `ScheduleWakeup` call)
-- A BLOCK finding triggers automatic cancellation of the cron job
+- You cancel the scheduled job by finding its id via `CronList`, then
+  running `CronDelete <job-id>`
+- A BLOCK finding: the agent cancels the loop as part of the BLOCK
+  workflow above (`CronList` + `CronDelete <job-id>`)

--- a/skills/audit-repo/SKILL.md
+++ b/skills/audit-repo/SKILL.md
@@ -221,8 +221,10 @@ Bright-line violation. Create a blocking issue:
 Append to {audit_dir}/log.md:
 "YYYY-MM-DD HH:MM — PR #N: BLOCK: <description> (issue #M created)"
 
-After creating the blocking issue and appending to the log, run
-`/loop stop` to halt the audit loop immediately.
+After creating the blocking issue and appending to the log, cancel the
+audit loop immediately: run `CronList` to find the job id, then
+`CronDelete <job-id>`. (For a self-pacing dynamic loop, omit the next
+`ScheduleWakeup` call instead.)
 
 ### Bright Lines (block immediately)
 - Projected steady-state cost exceeds $25/mo
@@ -334,5 +336,6 @@ WARN with a GitHub issue.
 
 The audit loop runs until:
 - You stop it manually (Ctrl-C or close the session)
-- You invoke `/loop stop`
-- A BLOCK finding triggers an automatic `/loop stop`
+- You cancel the scheduled job via `CronDelete <job-id>` (or, for a
+  self-pacing dynamic loop, by omitting the next `ScheduleWakeup` call)
+- A BLOCK finding triggers automatic cancellation of the cron job


### PR DESCRIPTION
## Summary
- Replace non-existent `/loop stop` subcommand with the real cancellation API (`CronList` + `CronDelete`, or omit next `ScheduleWakeup` for dynamic loops).

## Why
Addresses unresolved review thread 2 on merged PR #23 ([link](https://github.com/natecostello/agent-skills/pull/23#discussion_r3107843971)). As-written, invoking `/loop stop` would schedule the literal string "stop" as a prompt — silently failing to halt the audit loop on BLOCK findings.

## Test plan
- [ ] `./install.sh --list` still shows `audit-repo` with non-empty description
- [ ] Grep confirms no remaining `/loop stop` references in the skill
- [ ] Cross-check against `loop` skill's actual trigger description

🤖 Generated with [Claude Code](https://claude.com/claude-code)