### PR TITLE
Migrate new-adr → adr-new

### DIFF
--- a/skills/adr-init/SKILL.md
+++ b/skills/adr-init/SKILL.md
@@ -125,7 +125,7 @@ Do NOT write an ADR for: bug fixes, dependency updates, formatting changes, or r
 
 ### Superseding an existing ADR
 
-1. Draft a new ADR (via `/new-adr`) with the new decision
+1. Draft a new ADR (via `/adr-new`) with the new decision
 2. In the new ADR's frontmatter, add `related ADRs: "Supersedes ADR-NNNN"`
 3. In Context, explain why the prior decision is being revisited
 4. After human approves the new ADR:
@@ -182,9 +182,9 @@ Print a summary of what was created/modified:
 - Copilot instructions update suggestion (if applicable)
 
 Remind the user:
-- Use `/new-adr <title>` to create new ADRs
+- Use `/adr-new <title>` to create new ADRs
 - Existing decisions can be captured retroactively
-- The `/new-adr` skill uses the MADR 4.0 template with the project's conventions
+- The `/adr-new` skill uses the MADR 4.0 template with the project's conventions
 - If `.github/copilot-instructions.md` exists, run `/update-copilot-instructions` to add an ADR compliance focus area
 
 ## Additional Resources
@@ -192,4 +192,4 @@ Remind the user:
 ### Reference Files
 
 - **[`references/adr-readme-template.md`](references/adr-readme-template.md)** — Template for the ADR index README
-- The `/new-adr` skill contains the full MADR 4.0 ADR template in its `references/`
+- The `/adr-new` skill contains the full MADR 4.0 ADR template in its `references/`

--- a/skills/adr-new/SKILL.md
+++ b/skills/adr-new/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: adr-new
+description: >-
+  Create a new Architecture Decision Record. Use when the user says "new ADR",
+  "create ADR", "write an ADR", "document this decision", or needs to record an
+  architectural decision.
+license: MIT
+metadata:
+  author: natecostello
+  version: "0.1"
+disable-model-invocation: true
+argument-hint: "<short title of the decision, e.g. \"use SQLite for caching\">"
+---
+
+# Create a New Architecture Decision Record
+
+Create a new ADR in `docs/architecture/` following the MADR 4.0 template.
+
+## Workflow
+
+### 1. Verify ADR Directory Exists
+
+```bash
+ls docs/architecture/README.md 2>/dev/null
+```
+
+If the directory doesn't exist, stop and suggest running `/adr-init` first.
+
+### 2. Determine the Next ADR Number
+
+```bash
+ls docs/architecture/[0-9]*.md 2>/dev/null | sort -n | tail -1
+```
+
+Extract the highest number and increment by 1. Pad to 4 digits (e.g., `0004`).
+
+### 3. Gather Decision Context
+
+If `$ARGUMENTS` provides a title, use it. Otherwise, ask the user for:
+- What decision needs to be made?
+- What problem is this solving?
+
+Then research the codebase to understand the context:
+- Read relevant source files to understand current architecture
+- Check existing ADRs for related decisions
+- Identify the specific forces/constraints at play
+
+### 4. Draft the ADR
+
+Use the template in [references/template.md](references/template.md). Fill in:
+
+- **Frontmatter**: Set status to `proposed`, today's date, decision-makers (ask the user if not obvious)
+- **Title**: Short noun phrase (from argument or discussion)
+- **Context**: 2-5 sentences describing the problem and forces
+- **Decision Drivers**: 3-5 bullet points of constraints/requirements
+- **Considered Options**: Always include "Status quo / do nothing" as the baseline option. Include at least one additional alternative (ideally 2). Every rejected option must have a specific reason tied to an actual constraint — not vague ("too complex") but concrete ("incompatible with our no-external-runtime-deps constraint per ADR-0003")
+- **Decision Outcome**: Which option was chosen and why
+- **Consequences**: Good, neutral, and bad outcomes
+- **Confirmation**: How to verify correct implementation
+- **Pros and Cons**: Detailed analysis of each option
+- **More Information**: Leave as "To be implemented in PR #TBD" if the PR doesn't exist yet
+
+Related ADRs: Check existing ADRs and link any that are related.
+
+### 5. Write the File
+
+Write to `docs/architecture/NNNN-<kebab-case-title>.md`.
+
+### 6. Update the ADR Index
+
+Read `docs/architecture/README.md` and add a new row to the index table:
+
+```markdown
+| [NNNN](NNNN-kebab-case-title.md) | Short description | Proposed |
+```
+
+### 7. Report
+
+Print:
+- Path to the new ADR
+- Reminder to update status from `proposed` to `accepted` after the implementing PR merges
+- Reminder to update the "More Information" section with the PR number after submission

--- a/skills/adr-new/references/template.md
+++ b/skills/adr-new/references/template.md
@@ -1,0 +1,84 @@
+# MADR 4.0 ADR Template
+
+Use this template when creating a new ADR. Replace all `<angle bracket>` placeholders with concrete information. Remove guidance comments before saving.
+
+---
+
+```markdown
+---
+status: proposed
+date: <YYYY-MM-DD>
+decision-makers: <list of names/roles who made this decision>
+<!-- Optional RACI fields — include when relevant: -->
+<!-- consulted: <list of people whose input was sought> -->
+<!-- informed: <list of people who were notified> -->
+related ADRs:
+  - "<link and brief description of relationship>"
+---
+
+# <Short noun phrase describing the decision>
+
+## Context and Problem Statement
+
+<Describe the context and problem in 2-5 sentences. What forces are at play? Why does this decision need to be made now?>
+
+## Decision Drivers
+
+* <driver 1 — a concern, constraint, or requirement that shaped the decision>
+* <driver 2>
+* <driver 3>
+
+## Considered Options
+
+* <Option 1 title>
+* <Option 2 title>
+* <Option 3 title>
+
+## Decision Outcome
+
+Chosen option: "<Option title>", because <1-2 sentence justification tying back to decision drivers>.
+
+Plan: `<path>` (created at `<commit-hash>`, last version before deletion at `<commit-hash>~1`)
+<!-- Include the plan reference only if a planning document was created for this decision -->
+
+### Consequences
+
+* Good, because <positive consequence>
+* Good, because <positive consequence>
+* Neutral, because <neutral observation>
+* Bad, because <negative consequence or trade-off>
+
+### Confirmation
+
+<How will we verify the decision was implemented correctly? Reference specific tests, metrics, or verification steps.>
+
+## Pros and Cons of the Options
+
+### <Option 1 title>
+
+<1-2 sentence description of this option.>
+
+* Good, because <advantage>
+* Good, because <advantage>
+* Neutral, because <observation>
+* Bad, because <disadvantage>
+
+### <Option 2 title>
+
+<1-2 sentence description.>
+
+* Good, because <advantage>
+* Bad, because <disadvantage>
+
+### <Option 3 title>
+
+<1-2 sentence description.>
+
+* Good, because <advantage>
+* Bad, because <disadvantage>
+
+## More Information
+
+Implemented in PR #<number> (merged <date>).
+<!-- Add links to relevant discussions, external references, or amended ADRs -->
+```


### PR DESCRIPTION
## Summary
- Migrates `~/.claude/skills/new-adr/` into this repo as `skills/adr-new/` (renamed for autocomplete grouping with `adr-init`).
- Copies `SKILL.md` body and `references/template.md` verbatim, applies repo-standard frontmatter (license, metadata block, multi-line `description`), preserves `disable-model-invocation: true` and `argument-hint`.
- Updates internal `/init-adr` → `/adr-init` reference in the new skill.
- Also updates four stale `/new-adr` → `/adr-new` references in the sibling `adr-init` skill that this rename would otherwise break (symmetric companion change to step 4).

## Closes
Closes #10

## Plan compliance
- [x] Step 1 (create `skills/adr-new/`) — DONE
- [x] Step 2 (copy SKILL.md + references/) — DONE (template.md verbatim)
- [x] Step 3 (frontmatter to repo standard) — DONE
- [x] Step 4 (update `/init-adr` → `/adr-init`, `new-adr` self-refs → `adr-new`) — DONE; also fixed cross-references in `adr-init/SKILL.md`
- [x] Step 5 (commit + open PR) — DONE
- [ ] Step 6 (post-merge install + delete source) — DEFERRED to merge
- [ ] Step 7 (verify in fresh session) — DEFERRED to merge

## Test plan
- [x] `./install.sh --list` shows `adr-new` with full description
- [x] Frontmatter valid (`name: adr-new` matches dir, `license: MIT`, `metadata.author`, `metadata.version`)
- [x] `references/template.md` present and byte-identical to source
- [ ] Post-merge `./install.sh --global adr-new` runs clean
- [ ] Post-merge `~/.claude/skills/new-adr/` removed
- [ ] `/adr-new` invocable in a fresh Claude Code session

🤖 Generated with [Claude Code](https://claude.com/claude-code)