### PR TITLE
Migrate init-copilot-instructions → copilot-init

### DIFF
--- a/skills/copilot-init/SKILL.md
+++ b/skills/copilot-init/SKILL.md
@@ -28,7 +28,7 @@ git rev-parse --show-toplevel
 ls .github/copilot-instructions.md 2>/dev/null
 ```
 
-If the file exists, stop and suggest `/copilot-update` instead. Create `.github/` if absent.
+If the file exists, stop and suggest `/update-copilot-instructions` instead. Create `.github/` if absent.
 
 ### 2. Analyze the Repository
 
@@ -63,7 +63,7 @@ If `CLAUDE.md` exists, add a reference near the conventions or CI section:
 
 GitHub Copilot is configured as a PR code reviewer. Its instructions are in
 [`.github/copilot-instructions.md`](.github/copilot-instructions.md). Copilot reviews
-deliver inline comments with suggestion blocks. Use `/pr-resolve-comments` to process
+deliver inline comments with suggestion blocks. Use `/resolve-pr-comments` to process
 review feedback.
 ```
 
@@ -72,7 +72,7 @@ review feedback.
 Print what was created and remind about:
 - Enabling Copilot code review in repo Settings > Copilot > Code review
 - Adding Copilot as a default reviewer in branch protection rules
-- Using `/copilot-update` to keep the file current
+- Using `/update-copilot-instructions` to keep the file current
 
 ## Additional Resources
 

--- a/skills/copilot-init/SKILL.md
+++ b/skills/copilot-init/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: copilot-init
+description: >-
+  This skill should be used when the user asks to "set up copilot review",
+  "create copilot instructions", "initialize copilot", "add copilot as a
+  reviewer", "configure copilot for this repo", or needs to create a
+  .github/copilot-instructions.md file for GitHub Copilot code review.
+license: MIT
+metadata:
+  author: natecostello
+  version: "0.1"
+disable-model-invocation: true
+argument-hint: "[optional focus areas, e.g. \"focus on security\"]"
+---
+
+# Initialize Copilot Code Review Instructions
+
+Create `.github/copilot-instructions.md` to give GitHub Copilot the project context it needs for informed pull request reviews. Copilot is configured as a code reviewer only — not as a coding agent.
+
+## Workflow
+
+### 1. Verify Prerequisites
+
+Confirm this is a git repository and the file does not already exist:
+
+```bash
+git rev-parse --show-toplevel
+ls .github/copilot-instructions.md 2>/dev/null
+```
+
+If the file exists, stop and suggest `/copilot-update` instead. Create `.github/` if absent.
+
+### 2. Analyze the Repository
+
+Gather the following by reading actual files with Glob, Grep, and Read. Do not guess.
+
+**Project identity** — Read `README.md`, `CLAUDE.md`, or equivalent. Identify primary language(s), framework(s), project type (library, CLI, web app, API, monorepo).
+
+**Build and tooling** — Read `package.json`, `pyproject.toml`, `Cargo.toml`, `go.mod`, `Makefile`, or equivalent. Identify the package manager and extract exact commands for install, build, test, lint, format, and type check. Note environment variables and prerequisites.
+
+**Project layout** — List top-level directories and purposes. Identify source, test, and config file locations. Find CI/CD configuration in `.github/workflows/` or equivalent.
+
+**Architecture** — Identify major components, external service dependencies, and high-risk areas where changes have outsized impact.
+
+**Conventions** — Read linter/formatter config. Check `CLAUDE.md`, `CONTRIBUTING.md`, or style guides. Check commit conventions from recent `git log`.
+
+**Planning documents** — Check for `docs/` with architecture or planning documents that code should align with.
+
+**Note:** The template includes universal sections (Review Priority, Plan and Design Document Reviews) that apply to all repos. Always include these — they are not project-specific and should not be omitted.
+
+### 3. Write the File
+
+Create `.github/copilot-instructions.md` using the template in [references/template.md](references/template.md). Fill every section with concrete, verified information from Step 2. Omit sections that do not apply rather than writing placeholder content.
+
+If `$ARGUMENTS` specifies focus areas, emphasize those in the review focus areas section.
+
+### 4. Add CLAUDE.md Reference
+
+If `CLAUDE.md` exists, add a reference near the conventions or CI section:
+
+```markdown
+## Code Review
+
+GitHub Copilot is configured as a PR code reviewer. Its instructions are in
+[`.github/copilot-instructions.md`](.github/copilot-instructions.md). Copilot reviews
+deliver inline comments with suggestion blocks. Use `/pr-resolve-comments` to process
+review feedback.
+```
+
+### 5. Report
+
+Print what was created and remind about:
+- Enabling Copilot code review in repo Settings > Copilot > Code review
+- Adding Copilot as a default reviewer in branch protection rules
+- Using `/copilot-update` to keep the file current
+
+## Additional Resources
+
+### Reference Files
+
+- **[`references/template.md`](references/template.md)** — Complete template for `copilot-instructions.md` with all recommended sections and guidance comments

--- a/skills/copilot-init/references/template.md
+++ b/skills/copilot-init/references/template.md
@@ -4,7 +4,7 @@ Use this template when creating `.github/copilot-instructions.md`. Replace all `
 
 ---
 
-```markdown
+````markdown
 # Copilot Instructions
 
 ## Role
@@ -158,4 +158,4 @@ actual patterns. Examples:
 - Do not suggest reorganizing imports beyond what the linter enforces
 - Do not flag # noqa or # type: ignore without checking for a valid reason
 - Do not suggest adding __all__ exports — this is not a library>
-```
+````

--- a/skills/copilot-init/references/template.md
+++ b/skills/copilot-init/references/template.md
@@ -1,0 +1,161 @@
+# copilot-instructions.md Template
+
+Use this template when creating `.github/copilot-instructions.md`. Replace all `<angle bracket>` placeholders with concrete, verified information from the repository. Omit any section that does not apply.
+
+---
+
+```markdown
+# Copilot Instructions
+
+## Role
+
+You are a code reviewer only. Deliver all feedback as inline review comments with
+suggestion blocks on the PR. Include concrete code suggestions wherever possible
+rather than descriptive-only feedback.
+
+Do NOT act as a coding agent. Do NOT open sub-PRs, create branches, or push commits.
+All feedback must be review comments.
+
+## Repository Summary
+
+<1-3 sentences: what this project does, who it's for, what makes it distinctive.
+Include the primary language and framework.>
+
+## Build, Test, and Lint
+
+<Exact commands with brief notes. Adapt to the project's package manager.>
+
+```bash
+<install-command>      # Install dependencies
+<test-command>         # Run tests (<approximate time>)
+<lint-command>         # Lint
+<format-command>       # Format check
+<typecheck-command>    # Type check (if applicable)
+```
+
+<Environment variables needed at runtime, if any.>
+<Test categories, markers, or flags that control what runs.>
+
+## Architecture
+
+<Brief description of the system architecture: what the major components are,
+how they connect, and what external services they depend on.>
+
+<High-risk areas where changes have outsized impact. Examples:
+- "cloud/app.py deploys to Modal GPU — a broken deploy blocks all downstream work"
+- "src/db/migrations/ — migration errors are hard to reverse in production">
+
+## Project Layout
+
+<Tree or list of top-level directories and key files with one-line descriptions.>
+
+Configuration files:
+<List config files and what they configure. Examples:
+- pyproject.toml — dependencies, ruff config, mypy config, pytest config
+- .github/workflows/ci.yml — CI pipeline: lint, typecheck, test>
+
+## Key Abstractions
+
+<List the 3-8 most important types, classes, or interfaces with one-line descriptions.
+These are the things a reviewer needs to know exist to give useful feedback.>
+
+## Dependencies and Non-Obvious Relationships
+
+<Things not obvious from reading a single file. Examples:
+- "cloud/app.py has its own pip dependency list, separate from pyproject.toml"
+- "The test database is shared across test files — ordering matters"
+- "Style reference images must be 64px tall grayscale PNGs">
+
+## Planning Documents
+
+<If the repo has planning docs that code should align with, list them and tell the
+reviewer to check implementation against these plans. Omit if no planning docs exist.>
+
+## Coding Conventions
+
+<Concrete rules from linter config, CLAUDE.md, CONTRIBUTING.md. Only include
+conventions a reviewer should enforce. Examples:
+- Python 3.12+, managed with uv
+- from __future__ import annotations in every file
+- Type hints on all public function signatures
+- pathlib.Path for file paths, not string manipulation
+- Ruff for linting and formatting (line-length 99)>
+
+## Review Priority
+
+Focus review effort in this order. Do not spend budget on lower tiers until higher
+tiers have been thoroughly checked. A round that catches a typo but misses a silent
+data-loss bug is a failed review.
+
+1. **Correctness** — Would this work if implemented/deployed as written? Check data
+   flow between components, implicit assumptions, edge cases, join/key consistency,
+   and off-by-one or empty-input scenarios
+2. **Breaking changes** — Does this silently break existing behavior, contracts, or
+   downstream consumers?
+3. **Security** — Injection, data exposure, unsafe operations, credential handling
+4. **Compatibility** — Version requirements, platform assumptions, dependency
+   constraints that aren't documented
+5. **Consistency** — Naming, conventions, cross-reference accuracy
+6. **Cosmetics** — Formatting, wording, documentation polish
+
+## Plan and Design Document Reviews
+
+When reviewing plans, ADRs, RFCs, or other design documents (not code):
+
+- Verify described steps would work correctly if implemented as written
+- Check that data formats, schemas, and join keys are consistent across components
+- Flag implicit assumptions that could cause silent failures at implementation time
+- Check version or compatibility requirements are stated, not assumed
+- Verify edge cases are addressed (different input formats, missing data, empty sets)
+- Do not focus on prose style or markdown formatting — focus on technical soundness
+
+## Code Review Focus Areas
+
+<6-12 numbered items specific to THIS project. Each names a concrete thing to check
+and why it matters. Be specific enough that reviewers catch issues in the FIRST round.
+
+Include project-specific items AND applicable items from this checklist:
+
+1. **Type safety** — flag bare dict, list, tuple without type parameters
+2. **Security** — no hardcoded API keys, no command injection via string interpolation.
+   In shell scripts: use Bash arrays for file lists, not unquoted string expansion;
+   sanitize external input before interpolation
+3. **Error handling and fallbacks** — when a batch operation fails and is caught,
+   callers must not silently fall through to a misleading fallback. Track success
+   with explicit flags (e.g. `query_ok`) to distinguish "succeeded, no results"
+   from "failed" — each case should render differently
+4. **Truncation propagation** — when a function signals truncation (e.g. via a
+   sentinel key or flag on the last result), callers must detect it and surface
+   a notice or avoid claiming completeness
+5. **Multi-valued field parsing** — when a field can contain multiple
+   delimited values (e.g. comma/slash/pipe separated), always tokenize into
+   individual terms before matching. For protection checks, protect if ANY term
+   matches. For filtering, filter only if ALL terms match the criterion
+6. **N+1 query patterns** — flag loops that call a query function per item
+   when a batch API exists. Map batch results back to inputs by key
+7. **Code duplication** — shared helpers should live in a single module. Flag
+   any utility function duplicated across files
+8. **Input validation consistency** — when multiple code paths validate the
+   same input type, they must use identical validation logic (same regex,
+   same rules). Flag inconsistencies like startsWith vs regex
+9. **Shell script portability** — if scripts claim cross-platform support
+   (macOS/Linux), flag GNU-only flags (sort -V, sed -i without '', etc.)
+10. **Plan alignment** — verify implementation matches planning docs
+11. **Documentation consistency** — if the PR changes user-facing behavior, CLI
+    commands, flags, configuration, public interfaces, or architecture, check
+    whether `README.md` and `CLAUDE.md` were updated to match. Flag PRs that
+    change behavior without updating docs>
+
+<Keep only the items that apply to THIS project. Add project-specific items.
+The goal is 6-12 focused items that catch real issues on the first review round.>
+
+## What NOT to Flag
+
+<5-8 items that would waste reviewer and developer time. Tailor to the project's
+actual patterns. Examples:
+- Do not suggest adding docstrings to test functions
+- Do not flag print() in scripts — they use print deliberately, not logging
+- Do not suggest reorganizing imports beyond what the linter enforces
+- Do not flag # noqa or # type: ignore without checking for a valid reason
+- Do not suggest adding __all__ exports — this is not a library>
+```


### PR DESCRIPTION
## Summary
- Migrate `~/.claude/skills/init-copilot-instructions/` into `skills/copilot-init/`.
- Rename for prefix grouping with the forthcoming `copilot-update` skill.
- Preserve `disable-model-invocation` and `argument-hint` frontmatter; add repo-standard `license` / `metadata`.
- Update body references: `/update-copilot-instructions` → `/copilot-update` (sibling rename in #12) and `/resolve-pr-comments` → `/pr-resolve-comments` (epic rename map).

## Closes
Closes #11

## Plan compliance
- [x] Step 1 (create `skills/copilot-init/`) — DONE
- [x] Step 2 (copy `SKILL.md` + `references/` verbatim) — DONE
- [x] Step 3 (frontmatter: name, description, license, metadata; preserve `disable-model-invocation`, `argument-hint`) — DONE
- [x] Step 4 (body refs: self-rename + `/copilot-update`; also updated `/resolve-pr-comments` → `/pr-resolve-comments` per epic #6 rename map, matching `adr-init`/`adr-new` precedent) — DONE
- [ ] Step 5 (commit, PR, review) — in flight
- [ ] Step 6 (post-merge: `./install.sh --global copilot-init`, delete source) — deferred to post-merge
- [ ] Step 7 (verify `/copilot-init` in fresh session) — deferred to post-merge

## Test plan
- [x] `./install.sh --list` shows `copilot-init` with non-empty description
- [x] Frontmatter valid (name matches dir, license present, required metadata fields present)
- [x] `references/template.md` present
- [ ] Post-merge: `./install.sh --global copilot-init` and source deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)