### PR TITLE
Migrate media-coverage-analysis (strip .venv)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 *.swo
 *~
 
+# Python virtual environments (skills may bootstrap a local .venv/)
+.venv/
+
 # Local migration-epic tooling — not shipped with the repo
 temp-*
 .ralph-logs/

--- a/skills/media-coverage-analysis/SKILL.md
+++ b/skills/media-coverage-analysis/SKILL.md
@@ -1,0 +1,352 @@
+---
+name: media-coverage-analysis
+description: >-
+  Generate comprehensive media coverage and sentiment analysis reports for any news topic.
+  Produces a defensible, data-driven report with political spectrum analysis, article-level
+  sentiment scoring, government narrative alignment tracking, fact-checking, and visualizations.
+  Outputs both Markdown and PDF with clickable source links. Use this skill whenever the user
+  asks to analyze media coverage, sentiment, bias, or narrative framing around any news event
+  or topic — even if they don't use the exact phrase "media coverage analysis." Also trigger
+  when users ask for political spectrum analysis, media bias reports, or fact-check summaries.
+  MANDATORY TRIGGERS: media coverage, sentiment analysis, media bias, narrative framing,
+  political spectrum, fact-check, how media covered, news analysis.
+license: MIT
+metadata:
+  author: natecostello
+  version: "0.1"
+---
+
+# Media Coverage & Sentiment Analysis
+
+This skill produces a complete, defensible media coverage analysis report for any news topic.
+Every data point on every chart traces back to a specific article scored on a transparent rubric,
+so the reader can disagree with any individual score and see exactly how it was derived.
+
+## Setup
+
+The chart and PDF generator scripts require a Python environment with `matplotlib`, `numpy`,
+and `reportlab`. Bootstrap once with [`uv`](https://docs.astral.sh/uv/):
+
+```bash
+cd skills/media-coverage-analysis
+uv venv
+uv pip install -r requirements.txt
+```
+
+Run the scripts through the venv interpreter (adapt paths if you copy the templates into a
+working directory):
+
+```bash
+cd skills/media-coverage-analysis
+.venv/bin/python scripts/generate_charts_template.py
+.venv/bin/python scripts/generate_shift_chart_template.py
+.venv/bin/python scripts/generate_pdf_template.py
+```
+
+The NLP experimentation deps referenced in "TODO: Future Exploration" below (`torch`,
+`transformers`, `sentence-transformers`, `scikit-learn`) are **not** in `requirements.txt` —
+install them on demand if you pursue that work.
+
+## Why This Design
+
+Media analysis is inherently subjective. The skill addresses this by making every judgment
+explicit: each article gets four independent subscores on named criteria. Political orientation
+uses AllSides/Ad Fontes baselines with documented adjustments. Fact-check verdicts cite specific
+evidence. Government narrative alignment is a mathematical transform of sentiment, not a separate
+subjective judgment. This makes the report useful even to readers who disagree with individual
+scores — they can see where to push back.
+
+## Hard Rules
+
+These apply to every report, no exceptions:
+
+1. **PDF is a first-class citizen.** The PDF must look as good as the Markdown. If a feature
+   (emoji, Unicode symbol, etc.) does not render correctly in ReportLab, do not use it. Use
+   text-only verdicts (e.g., "[FALSE]", "[MISLEADING]") rather than emoji symbols.
+2. **Section structure is required.** The numbered sections and appendices defined in
+   `references/report-structure.md` are the minimum required structure. All 12 sections must
+   appear in the specified order. Sections may be expanded but never removed or reordered.
+3. **Multiple articles per outlet are required for shift analysis.** The shift over time within
+   outlets is a core analytical finding. For every outlet in the dataset, actively search for
+   2+ articles across different time periods. A dataset with mostly single-article outlets
+   produces flat, uninteresting shift arrows and misses the story. Target 3+ articles for
+   major outlets (NPR, Fox News, CNN, etc.).
+4. **Searches must be exhaustive.** For every outlet in the search matrix, run at least 2–3
+   different query formulations (different keywords, date ranges, topic angles). A single
+   failed search does not mean absence of coverage — it means the search was insufficient.
+   Only declare "no coverage found" after 3+ distinct search attempts with varied terms.
+5. **Government social media is part of the timeline.** Presidential tweets/truths, cabinet
+   members' social media posts, and official government social media are events that belong
+   in the Section 2 timeline. A presidential truth posted before the topical event (e.g.,
+   foreshadowing rhetoric) is timeline-relevant even though it predates the event. These do
+   NOT appear in the sentiment analysis (Sections 4–5), which is limited to published articles
+   after the topical event date.
+6. **No overlapping text.** Timeline charts (Sections 2 and 5) must implement collision
+   avoidance for text boxes. Labels must be size-aware and repositioned or staggered to avoid
+   obscuring each other. See `references/chart-specifications.md` for implementation.
+7. **Standard category ordering.** Wherever political categories appear in charts or narrative
+   sections, use the standard order defined in `references/chart-specifications.md`.
+8. **Colors and markers are standardized.** The color palette and marker shapes in
+   `references/chart-specifications.md` are canonical. Every chart must use them consistently.
+   Do not invent ad-hoc colors.
+9. **Primary-source legal and policy research is required.** For any topic involving government
+   action, enforcement, or policy disputes, search for court filings, judicial rulings, executive
+   orders, agency directives, and internal policy memos. These are the strongest evidence
+   available and must be cited with specific case numbers, judge names, and ruling dates.
+   Media descriptions of legal developments are secondary — the filings themselves are primary.
+   See Step 2 for the detailed research protocol.
+
+## Workflow
+
+Follow these steps in order. The reference files contain the detailed specifications; this
+section provides the high-level flow and the reasoning behind each step.
+
+### Step 1: Understand the Topic
+
+Before any research, establish four things:
+
+- **The core event**: What happened, when, who was involved
+- **The topic window**: Date range for coverage (typically the event date through the present)
+- **The key tension**: What makes coverage diverge? (competing accounts, political fault lines, evolving evidence)
+- **The official/government narrative**: If one exists, this becomes the alignment baseline
+
+Write these down — they inform every subsequent step. The "topical event date" is especially
+important because the alignment chart must not include data points before it.
+
+### Step 2: Research Systematically
+
+Read `references/scoring-rubric.md` Section 2 for the outlet spectrum before starting research.
+
+Search for 40–80 articles from 20+ outlets spanning far-left through far-right, plus
+libertarian, local, and government/official sources. Use outlet-specific searches
+(e.g., `site:foxnews.com [topic]`) and general date-filtered searches. **Prioritize
+depth over breadth:** 3 articles from one outlet showing a shift over time are more
+valuable than 3 articles from 3 outlets showing a single snapshot each.
+
+**MANDATORY: Search every political category explicitly.** Do not assume absence — verify it.
+Run dedicated searches for outlets in each of these categories. If an outlet has no coverage,
+record that as a finding (absence is data). Search at minimum:
+
+| Category | Minimum Outlets to Search | Search Method |
+|----------|--------------------------|---------------|
+| Far Left | The Intercept, Common Dreams, Jacobin | `site:` searches + general |
+| Left | Salon, Daily Beast, Mother Jones, HuffPost, Raw Story | `site:` searches |
+| Center-Left | NPR, PBS, CNN, WaPo, MSNBC | `site:` searches |
+| Center | AP, Reuters, ABC, CBS, NBC | `site:` searches |
+| Center-Right | WSJ, NY Post, Fox local affiliates | `site:` searches |
+| Right | Fox News, Washington Times, Washington Examiner, National Review | `site:` searches |
+| Far Right | Daily Wire, Breitbart, Newsmax, OANN, Daily Caller, Townhall, The Federalist, Epoch Times, RedState, The Blaze | **Must search each individually** |
+| Libertarian | Reason, Cato Institute | `site:` searches |
+| Government | DHS, DOJ, White House, relevant agencies | `site:` searches |
+| Local | 3+ outlets local to the event | general + `site:` searches |
+
+The far-right category requires individual `site:` searches for each outlet because these
+outlets often cover initial government narratives but not subsequent contradictions — and
+documenting that asymmetry is a core analytical finding. A general search like
+`"[topic]" breitbart OR newsmax` will miss articles that don't use the exact search terms.
+
+**MANDATORY: Search each time period separately.** For stories that evolve over time, run
+separate searches for each major phase (e.g., initial incident, charges/legal developments,
+evidence release). Right-leaning outlets frequently cover Phase 1 (government narrative
+intact) but not Phase 2 (narrative contradicted). Left-leaning outlets may do the reverse.
+Searching only the most recent period will systematically miss early coverage from outlets
+that later went silent, and vice versa.
+
+For each article, record: outlet, date, headline, URL, and enough content to score it. Aim
+for temporal coverage too — articles from both the initial reporting period and later
+developments, because the shift over time is where the interesting story lives.
+
+The research phase is the most time-consuming step and the one most likely to need multiple
+search rounds. Be thorough — a thin dataset produces unconvincing charts.
+
+**MANDATORY: Search government social media.** Search for presidential tweets/truths,
+cabinet-level social media posts, and official agency social media related to the topic.
+These are timeline events (Section 2) and provide context for the narrative environment
+even when they predate the topical event. Example: a presidential truth posted the day
+before an operation begins is a timeline event.
+
+**MANDATORY: Run multiple query formulations per outlet.** For each outlet in the search
+matrix, use at least 2–3 different search queries (different keywords, name variants,
+topic angles). A single `site:motherjones.com "renee good"` returning zero results does
+NOT establish absence — try `site:motherjones.com ICE shooting Minneapolis`, try without
+`site:` using `motherjones "ice shooting"`, etc. Only declare "no coverage found" after
+3+ genuinely distinct attempts. Coverage absence from outlets like Mother Jones, ProPublica,
+BBC, Guardian, NY Post, or WSJ for a major national story is improbable and warrants
+extra search effort before accepting.
+
+**After research, create a coverage gap audit:** List every outlet searched, the specific
+queries used, and whether coverage was found. This becomes part of the Methodology section
+and prevents silent omissions from weakening the analysis. The audit should document the
+search effort, not just the result.
+
+**MANDATORY: Search for primary-source legal and policy documents.** For any topic involving
+government action, enforcement, civil liberties, or policy disputes, media articles alone are
+insufficient. The strongest evidence for the timeline, fact-checks, and narrative analysis
+comes from primary legal and policy sources. Search for ALL of the following that apply:
+
+| Source Type | What to Search For | Where to Search |
+|------------|-------------------|-----------------|
+| **Court filings** | Lawsuits, complaints, motions for TRO/PI, amicus briefs | PACER, CourtListener, `site:courtlistener.com`, news reports citing case numbers |
+| **Judicial rulings** | Temporary restraining orders, preliminary injunctions, opinions | Same as above, plus `site:law.justia.com`, legal news outlets |
+| **Executive orders** | Presidential EOs, national security memoranda, presidential directives | `site:whitehouse.gov`, Federal Register, media coverage |
+| **Agency directives** | DHS/DOJ/ICE policy memos, operational guidance, internal directives | Agency websites, FOIA releases, investigative reporting |
+| **AG memoranda** | Attorney General memos to federal prosecutors, policy guidance | `site:justice.gov`, legal news |
+| **State legal actions** | State AG lawsuits, state court filings, governor executive orders | State AG websites, local legal news |
+| **Legislative actions** | Bills, committee hearings, floor statements, testimony transcripts | `site:congress.gov`, C-SPAN, committee websites |
+
+**Search strategy for legal sources:**
+1. Start with case names mentioned in media coverage — articles often reference lawsuits
+   by name (e.g., "ACLU v. DHS") without providing full case details
+2. Search for the full case number, presiding judge, and specific rulings
+3. Search for related cases — one lawsuit often spawns related filings in other jurisdictions
+4. Search for the specific legal theories cited (e.g., First Amendment, APA violations,
+   42 U.S.C. § 1983) to find additional cases
+5. Check legal news outlets (Law360, Reuters Legal, SCOTUSblog, Lawfare) for analysis
+
+**What to record for each primary source:**
+- Full case name and number (e.g., *LA Press Club v. Noem*, No. 2:25-cv-01494)
+- Presiding judge
+- Date of filing and date of ruling (if applicable)
+- Specific holding or key language from the ruling
+- Which media outlets reported on it and which did not (this is an analytical finding)
+
+**Why this matters:** Court filings and judicial rulings are the strongest possible evidence
+for fact-checks. A judge's finding that "X is not supported by the evidence" carries more
+weight than any number of media articles arguing the same point. When a judge issues a
+preliminary injunction, they have made a legal determination that the plaintiff is likely
+to succeed on the merits — this is a factual finding, not editorial opinion. Legal primary
+sources also reveal asymmetric coverage patterns: outlets that covered the initial government
+claim but not the subsequent judicial rejection of that claim are exhibiting a documentable
+information gap.
+
+These primary sources should be integrated into:
+- **Section 2 (Timeline):** Court filings, rulings, and executive orders are timeline events
+- **Section 10 (Fact-Checks):** Judicial findings are top-tier evidence for verdicts
+- **Section 3 (Narrative Analysis):** Which outlets covered legal developments and which didn't
+- **Section 9 (Methodology):** Document the primary sources consulted
+
+### Step 3: Score Each Article
+
+**Read `references/scoring-rubric.md` before scoring any articles.** This is the most critical
+step for consistency and defensibility.
+
+The rubric has four criteria, each scored –0.25 to +0.25:
+1. Subject description (how the subject is named/characterized)
+2. Account primacy (whose version leads the article)
+3. Emotional register (the article's affective tone)
+4. Immigration/identity status foregrounding (for topics where this applies; otherwise substitute
+   an equivalent framing criterion relevant to the topic)
+
+Score what you observe in the text, not what you infer about intent. When uncertain, score
+toward 0. Document the breakdown as `"+.25/+.20/+.15/+.10"`.
+
+### Step 4: Identify and Fact-Check Claims
+
+**Read `references/fact-checking-guide.md`** before writing this section.
+
+Identify 4–8 key assertions made in coverage — especially claims from official sources that
+were widely repeated and later challenged by evidence. For each claim, document: how it was
+stated, by whom, what the evidence shows, a verdict, and article IDs as citations.
+
+### Step 5: Build the Article Dataset
+
+Create `article_data.py` in the working directory. This single file is the source of truth for
+all charts and both appendices. Read `references/chart-specifications.md` Section 1 for the
+exact data structure.
+
+### Step 6: Generate Charts
+
+**Read `references/chart-specifications.md`** for full specs. There are 6 charts:
+
+1. **Timeline** — key events with color-coded markers
+2. **Sentiment Scatter** — outlet-level static positioning
+3. **Article-Level Shift** — every article as a recency-encoded point with chronological arrows
+4. **Timeline + Alignment** — events above, government narrative alignment traces below
+5. **Coverage Volume** — pie chart by source type
+6. **Framing** — bar chart of narrative emphasis by political category
+
+Adapt the template scripts in `scripts/` for the specific topic. The chart specs contain the
+exact color palette, marker shapes, axis labels, and computation methods.
+
+### Step 7: Assemble the Report
+
+**Read `references/report-structure.md`** for the exact section ordering. The report includes:
+
+- Executive Summary
+- Timeline of Key Events (chart + table)
+- Sentiment & Narrative Analysis (by political category)
+- Sentiment Map & Shift Over Time (article-level chart)
+- Timeline & Government Narrative Alignment (combined chart)
+- Coverage Volume
+- Narrative Framing
+- Public Sentiment Indicators
+- Methodology Note
+- Fact-Check Section (claims + summary table)
+- Appendix A: Scoring Rubric & All Articles (with links)
+- Appendix B: Government Narrative Alignment Basis Data (with links)
+
+Output both Markdown (.md) and PDF formats. The PDF must have clickable links throughout.
+
+### Step 8: Verify
+
+Read every page of the generated PDF. Check that:
+- All charts render and are readable
+- Tables don't overflow margins
+- Links are blue and present in appendices and fact-check sources
+- Article counts match between the dataset, charts, and appendix
+- Fact-check verdicts match the summary table
+- **No emoji or broken Unicode characters anywhere** — look for black squares, question marks,
+  or tofu (□) that indicate failed rendering
+- **Pie chart is perfectly circular**, not oblong
+- **Timeline text boxes do not overlap** — all labels must be readable
+- **Multiple articles per outlet** — verify the shift chart shows arrows for major outlets,
+  indicating temporal coverage depth (not just single snapshots)
+- **All 12 sections present** in the correct order
+
+## Key Formulas
+
+**Government Narrative Alignment:**
+```
+alignment = (1 - sentiment) / 2
+```
+Maps sentiment [–1, +1] to alignment [0, 1]. The "government narrative" is whatever the official
+institutional position is — in many stories this means hostile-to-subject = high alignment.
+
+**Alignment Trace (latest-per-outlet):** At each date, the group average uses only each
+outlet's most recent article. When an outlet publishes again, the old score drops out.
+One point per unique date per category. This means the trace responds to editorial shifts
+rather than being dragged by early coverage.
+
+**Recency Encoding (shift chart):**
+```
+alpha = 0.20 + 0.80 * (days_since_earliest / total_days)
+size  = 50  + 130  * (days_since_earliest / total_days)
+```
+
+## TODO: Future Exploration
+
+- **NLP-based sentiment scoring (Sections 4A/5A):** Explore automated sentiment analysis as
+  a complement to the manual rubric. Initial testing with zero-shot NLI (BART-MNLI) on headlines
+  showed r=0.066 correlation with manual scores — the model confuses lexical violence with
+  editorial hostility. SBERT embedding alignment showed r=0.044 — topical similarity dominates
+  stance signal. Three improvements to try:
+  1. **Scrape article ledes** (first 500 words) instead of headline-only input
+  2. **Multi-axis NLI hypotheses** mirroring the 4 rubric criteria (subject description, account
+     primacy, emotional register, status foregrounding) instead of a single sympathetic/hostile
+     dimension
+  3. **Contrastive SBERT** measuring difference between similarity to government-narrative and
+     counter-narrative reference texts, canceling out shared topical vocabulary
+  - Venv with torch/transformers/sentence-transformers is at `.venv/` in the skill directory
+  - See the Renee Good report working directory for the initial `compute_nlp_sentiment.py` script
+    and comparison charts
+
+## Reference Files
+
+Read these at the points indicated in the workflow:
+
+| File | When to Read | Contents |
+|------|-------------|----------|
+| `references/scoring-rubric.md` | Before Step 3 | 4-criterion rubric, political orientation method, calibration |
+| `references/fact-checking-guide.md` | Before Step 4 | Claim identification, evidence evaluation, verdict assignment |
+| `references/report-structure.md` | Before Step 7 | Exact sections, ordering, formatting for Markdown and PDF |
+| `references/chart-specifications.md` | Before Steps 5–6 | Data structures, chart specs, colors, alignment computation |

--- a/skills/media-coverage-analysis/references/chart-specifications.md
+++ b/skills/media-coverage-analysis/references/chart-specifications.md
@@ -1,0 +1,366 @@
+# Chart Specifications
+
+This document defines the data structures, visual specifications, and computation methods
+for all 6 charts in the report.
+
+**STANDARDIZATION RULE:** The color palette (Section 2) and marker shapes (Section 3) are
+canonical. Every chart in every report must use these exact colors and markers for the
+corresponding political categories. Do not invent ad-hoc colors or markers. If a new
+category is needed, define it here first.
+
+## 1. Article Dataset (`article_data.py`)
+
+This file is the single source of truth. All charts and both appendices draw from it.
+
+### Structure
+
+```python
+from datetime import datetime
+
+# Each article: (outlet, article_id, date, y_sentiment, headline, url, score_breakdown)
+ARTICLES = [
+    ("The Intercept", "A1a", datetime(2026, 1, 7), 0.90,
+     "This Isn't the First Killing by ICE",
+     "https://theintercept.com/...",
+     "+.25/+.25/+.25/+.15"),
+    # ... one entry per article
+]
+
+# Political x-position for each outlet (from scoring-rubric.md)
+OUTLET_X = {
+    "The Intercept": -2.8,
+    "Fox News": 1.8,
+    # ... one entry per outlet
+}
+
+# Category for marker shapes
+OUTLET_CAT = {
+    "The Intercept": "left",
+    "Fox News": "right",
+    # ... one entry per outlet
+}
+```
+
+### Article ID Convention
+
+Use `[Outlet Abbreviation][Letter][Sequence]`:
+- `A1a` = first outlet, first article
+- `A1b` = first outlet, second article
+- Number outlets roughly left-to-right
+- Letter suffix `a`, `b`, `c` for chronological articles within an outlet
+
+### Completeness Check
+
+Every outlet in ARTICLES must have an entry in both OUTLET_X and OUTLET_CAT.
+Every article must have all 7 fields populated (url can be empty string for unavailable links).
+
+## 2. Color Palette
+
+```python
+LEFT_C    = '#2171b5'  # Blue
+CENTER_C  = '#6a51a3'  # Purple
+RIGHT_C   = '#cb181d'  # Red
+LIBERT_C  = '#f59e0b'  # Amber
+GOV_C     = '#525252'  # Dark gray
+NEUTRAL_C = '#737373'  # Gray
+
+# Event marker colors
+SHOOTING_C = '#e31a1c'  # Red (shooting events)
+EVIDENCE_C = '#2ca02c'  # Green (evidence/accountability events)
+INFO_C     = '#1f77b4'  # Blue (government/public/media events)
+```
+
+## 3. Marker Shapes by Category
+
+```python
+cat_style = {
+    'left':         (LEFT_C,    's'),    # Square
+    'center-left':  ('#4292c6', 'D'),    # Diamond
+    'center':       (CENTER_C,  'o'),    # Circle
+    'center-right': ('#fb6a4a', 'D'),    # Diamond
+    'right':        (RIGHT_C,   '^'),    # Triangle up
+    'libertarian':  (LIBERT_C,  'P'),    # Plus (filled)
+    'gov':          (GOV_C,     'X'),    # X
+}
+```
+
+## 4. Chart 1: Timeline (`chart_timeline.png`)
+
+A horizontal timeline showing key events with colored markers.
+
+- **Figure size**: 16×5 inches
+- **Layout**: Events placed at alternating y-positions above and below the axis
+- **Markers**: Colored circles (red for shootings, green for evidence/accountability, blue for govt/public)
+- **Labels**: Event text with date, connected to marker by vertical line
+- **X-axis**: Date range covering the full topic window
+- **Legend**: Marker color meanings
+
+Events are defined as tuples: `(date, label, side, category)` where:
+- `side`: 'up' or 'down' for alternating placement
+- `category`: 'shooting', 'evidence', 'govt', 'public' → determines color
+
+**CRITICAL: Text box collision avoidance.** Timeline labels MUST NOT overlap each other.
+Use a greedy slot-based stagger algorithm:
+
+1. For each event, check ALL prior same-side events within a **computed** proximity window.
+2. Starting at the base y-position, check if any nearby label occupies that slot.
+3. If occupied, increment y (for 'up') or decrement y (for 'down') by the step size.
+4. Repeat until a clear slot is found.
+5. The same collision avoidance applies to the top panel of Chart 4 (combined timeline).
+
+**CRITICAL: Computing `proximity_days`.** The proximity window must reflect the actual width
+of rendered text boxes in date-axis units, NOT a small fixed number of days. A label rendered
+at 6pt font is approximately 1.5 inches wide on a typical chart. To convert this to days:
+
+```
+proximity_days = (date_range_days / usable_figure_width_inches) * label_width_inches * 1.2
+```
+
+For example:
+- Chart 1 (standalone timeline): 380-day range on a 20-inch figure ≈ 19 days/inch.
+  A 1.5-inch label spans ~28 days. With 1.2x safety margin → **proximity_days ≈ 55**.
+- Chart 4 (combined timeline): 230-day range on a 14-inch usable width ≈ 16 days/inch.
+  A 1.2-inch label at 5pt spans ~20 days. With 1.2x safety margin → **proximity_days ≈ 35**.
+
+**Never use `proximity_days=3`.** That value only catches events on literally the same day and
+guarantees overlapping labels for any real-world timeline. Always compute the value from the
+date range and figure dimensions. When in doubt, use a larger value — extra vertical stagger
+is always preferable to overlapping text.
+
+Implementation pattern:
+```python
+def _stagger_y_positions(events, base_up=1.0, base_down=-1.0, step=0.8, proximity_days=55):
+    y_positions = []
+    up_placed, down_placed = [], []
+    for i, (d, label, side, cat) in enumerate(events):
+        if side == 'up':
+            nearby_ys = [py for pd, py in up_placed if abs((d - pd).days) <= proximity_days]
+            y = base_up
+            while any(abs(y - ny) < step for ny in nearby_ys):
+                y += step
+            up_placed.append((d, y))
+        else:
+            nearby_ys = [py for pd, py in down_placed if abs((d - pd).days) <= proximity_days]
+            y = base_down
+            while any(abs(y - ny) < step for ny in nearby_ys):
+                y -= step
+            down_placed.append((d, y))
+        y_positions.append(y)
+    return y_positions
+```
+
+**Figure height must accommodate stagger depth.** Dense event clusters require 3+ stagger
+levels. Use `figsize=(22, 10)` for standalone timelines and `set_ylim(-6.5, 6.5)` to provide
+room. For Chart 4's top panel, use `set_ylim(-5.5, 5.5)`. Reduce font size to 6pt for
+standalone timelines and 5pt for Chart 4's top panel.
+
+Labels should be concise — aim for ≤25 characters per line, 2 lines maximum. If a label
+requires 3+ lines or exceeds 25 chars/line, shorten it. Shorter labels reduce the required
+proximity_days and produce cleaner charts.
+
+## 5. Chart 2: Sentiment Scatter (`chart_sentiment_scatter.png`)
+
+Static outlet-level scatter plot (one point per outlet, not per article).
+
+- **Figure size**: 16×10 inches
+- **X-axis**: Political orientation (–3.5 to +3.5)
+- **Y-axis**: Average sentiment (–1.15 to +1.15)
+- **Points**: Marker shape and color by category
+- **Labels**: Outlet name next to each point
+- **Reference lines**: Dashed gray lines at x=0 and y=0
+- **Quadrant labels**: "Left + Sympathetic", "Right + Hostile", etc.
+- **Legend**: Marker shapes explained
+
+For outlets with multiple articles, use the average sentiment as the y-position.
+
+**CRITICAL: Label collision avoidance.** With 20+ outlets, labels will overlap unless
+actively repelled. Use an iterative repulsion algorithm:
+
+1. Collect initial label positions (offset slightly from the data point).
+2. Estimate each label's bounding box in data coordinates (character width ≈ x_range/110,
+   label height ≈ y_range/35).
+3. For each pair of labels, check if bounding boxes overlap.
+4. If overlapping, push apart — primarily vertically, with slight horizontal displacement
+   when labels are nearly co-located.
+5. Iterate 50 times or until no labels move.
+6. Draw thin leader lines from data points to displaced labels.
+
+Implementation pattern:
+```python
+def _repel_labels(labels_data, x_range=7.0, y_range=2.3, iterations=50):
+    """labels_data: list of [x, y, name] — positions updated in-place."""
+    char_w = x_range / 110
+    label_h = y_range / 35
+    for _ in range(iterations):
+        moved = False
+        for i in range(len(labels_data)):
+            for j in range(i + 1, len(labels_data)):
+                xi, yi = labels_data[i][0], labels_data[i][1]
+                xj, yj = labels_data[j][0], labels_data[j][1]
+                wi = len(labels_data[i][2]) * char_w
+                wj = len(labels_data[j][2]) * char_w
+                dx = abs(xi - xj)
+                dy = abs(yi - yj)
+                min_dx = (wi + wj) / 2
+                min_dy = label_h
+                if dx < min_dx and dy < min_dy:
+                    push_y = (min_dy - dy) / 2 + 0.02
+                    push_x = (min_dx - dx) * 0.15 if dx < min_dx * 0.5 else 0
+                    if yi >= yj:
+                        labels_data[i][1] += push_y; labels_data[j][1] -= push_y
+                    else:
+                        labels_data[i][1] -= push_y; labels_data[j][1] += push_y
+                    if xi >= xj:
+                        labels_data[i][0] += push_x; labels_data[j][0] -= push_x
+                    else:
+                        labels_data[i][0] -= push_x; labels_data[j][0] += push_x
+                    moved = True
+        if not moved:
+            break
+```
+
+After repulsion, draw leader lines from each data point to its displaced label position
+when the displacement exceeds a threshold (e.g., distance > 0.15 in data coordinates).
+Use thin, semi-transparent lines (`'-', color='#999', alpha=0.3, lw=0.5`).
+
+The same repulsion approach applies to both Chart 2 (outlet-level) and Chart 3
+(article-level, labeling each outlet's latest article).
+
+## 6. Chart 3: Article-Level Shift (`chart_sentiment_shift.png`)
+
+Every article as an individual point, with recency encoding and chronological arrows.
+
+- **Figure size**: 16×10 inches
+- **X-axis**: Political orientation (–3.5 to +3.5)
+- **Y-axis**: Sentiment (–1.15 to +1.15)
+- **Point size**: Recency-encoded: `size = 50 + 130 * frac` where frac = normalized date position
+- **Point opacity**: Recency-encoded: `alpha = 0.20 + 0.80 * frac`
+- **Arrows**: Connect articles from the same outlet chronologically (earlier → later)
+  - Arrow alpha = `min(alpha_start, alpha_end) * 0.5`
+  - Only draw if |dy| > 0.02 (skip trivial shifts)
+- **Labels**: Latest article for each outlet labeled in bold; earliest labeled faintly
+- **Legend**: Explains faded/small = earlier, bold/large = later, plus marker shapes
+- **Footer text**: Article count, explanation of encoding
+
+## 7. Chart 4: Timeline + Alignment (`chart_combined_timeline_shift.png`)
+
+Two-panel chart with shared x-axis. Timeline events on top, alignment traces below.
+
+- **Figure size**: 16×10 inches
+- **Layout**: 2 subplots, height ratio 3:2, shared x-axis
+- **Top panel**: Same as Chart 1 timeline but abbreviated to start at the topical event
+- **Bottom panel**: Government narrative alignment traces by category
+
+### Alignment Computation (Bottom Panel)
+
+**Formula:** `alignment = (1 - sentiment) / 2`
+
+**Trace method (latest-per-outlet):**
+1. Sort all articles in a category by date
+2. Group by date (bucket to the day)
+3. For each date group, update the "latest" dict with each outlet's newest score
+4. Compute the group average = mean of all outlets' latest scores
+5. Emit one point per unique date
+
+```python
+def build_latest_per_outlet_avg(points):
+    """points = [(outlet, date, alignment), ...]"""
+    sorted_pts = sorted(points, key=lambda p: p[1])
+    latest = {}  # outlet -> latest alignment
+    by_date = OrderedDict()
+    for outlet, d, v in sorted_pts:
+        if d not in by_date:
+            by_date[d] = []
+        by_date[d].append((outlet, v))
+    dates_out, avgs_out = [], []
+    for d, articles in by_date.items():
+        for outlet, v in articles:
+            latest[outlet] = v
+        avg = sum(latest.values()) / len(latest)
+        dates_out.append(d)
+        avgs_out.append(avg)
+    return dates_out, avgs_out
+```
+
+**Broad categories for traces:**
+- Far-Right: `cat == 'right'` and `x >= 2.3`
+- Right: `cat == 'right'` and `x < 2.3`
+- Center: `cat in ('center', 'center-right')`
+- Center-Left: `cat == 'center-left'`
+- Left: `cat == 'left'`
+- Libertarian: `cat == 'libertarian'`
+- Government/official: **excluded** from traces
+
+**Trace styles:**
+```python
+trace_styles = {
+    'Far-Right':    ('v-',  '#800000', 2.5, 7),  # Triangle down, maroon
+    'Right':        ('o-',  RIGHT_C,   2.5, 7),  # Circle, red
+    'Center':       ('s--', CENTER_C,  2.0, 6),  # Square dashed, purple
+    'Center-Left':  ('D--', '#4292c6', 2.0, 6),  # Diamond dashed, blue
+    'Left':         ('D:',  LEFT_C,    2.0, 6),  # Diamond dotted, blue
+    'Libertarian':  ('P-.', LIBERT_C,  2.0, 7),  # Plus dash-dot, amber
+}
+```
+
+**X-axis limits:** Start at topical event date minus 2 days, end at report date plus 2 days.
+(Not the full topic window — only the portion with article data.)
+
+**Y-axis:** 0 to 1.1 (alignment scale)
+
+**Filtering:** Only include articles on or after the topical event date. Pre-event articles
+are excluded from the alignment chart even if they exist in the dataset.
+
+## 8. Chart 5: Coverage Volume (`chart_coverage_volume.png`)
+
+Pie chart showing estimated coverage volume by source type.
+
+- **Figure size**: 8×8 inches
+- **CRITICAL: The pie chart must be perfectly circular.** Use `ax.set_aspect('equal')` to
+  enforce a 1:1 aspect ratio. The `figsize` alone is not sufficient — matplotlib may still
+  produce an oblong chart without the explicit aspect setting. Always call:
+  ```python
+  ax.set_aspect('equal')
+  ```
+- **Categories**: Center-Left/Mainstream, Left/Progressive, Right/Conservative, Far Right,
+  Local, Wire (AP/Reuters), Libertarian, Govt
+- **Colors**: Match the color palette above
+- **Labels**: Category name + percentage
+
+Coverage volume is estimated from search-result frequency, not counted precisely. This is
+an approximate visualization — note this in the methodology.
+
+## 9. Chart 6: Framing (`chart_framing.png`)
+
+Grouped bar chart showing narrative framing emphasis by political category.
+
+- **Figure size**: 12×7 inches
+- **Categories (x-axis groups) — STANDARD ORDER:** Far Left, Left, Center-Left, Center,
+  Center-Right, Right, Far Right, Libertarian. This left-to-right ordering with Libertarian
+  last (as a cross-spectrum outlier) is fixed across all reports. Not every category needs
+  data — omit categories with no articles — but the order of those present must follow this
+  sequence.
+- **Framing dimensions** (bars within each group): Sympathy for subject, Govt credibility
+  concern, Civil liberties emphasis, Immigration-status emphasis (or equivalent topic-specific
+  dimension)
+- **Y-axis**: 0 to 1.0 (emphasis level)
+- **Colors**: One color per framing dimension
+
+The framing values are qualitative judgments based on the scored articles — they represent
+the analyst's assessment of how much emphasis each category placed on each framing dimension,
+not a mechanical computation.
+
+## 10. Global Matplotlib Settings
+
+```python
+plt.rcParams.update({
+    'figure.facecolor': '#fafafa',
+    'axes.facecolor': '#fafafa',
+    'font.family': 'sans-serif',
+    'font.size': 11,
+    'axes.titlesize': 14,
+    'axes.titleweight': 'bold',
+})
+```
+
+All charts saved at 150 DPI with `bbox_inches='tight'`.

--- a/skills/media-coverage-analysis/references/fact-checking-guide.md
+++ b/skills/media-coverage-analysis/references/fact-checking-guide.md
@@ -1,0 +1,158 @@
+# Fact-Checking Guide
+
+This document describes how to identify claims, evaluate evidence, and assign verdicts for
+the fact-check section of the report.
+
+## 1. Identifying Claims
+
+Look for assertions that meet ALL of these criteria:
+
+- **Widely repeated**: The claim appeared in multiple outlets, not just one
+- **Consequential**: The claim shaped how readers understood the event
+- **Verifiable**: There exists (or should exist) evidence that can confirm or contradict it
+- **Contested**: At least some outlets or sources challenged the claim
+
+Good fact-check subjects are often official claims that were initially taken at face value
+and later contradicted by evidence. Government press releases, official statements, and
+sworn testimony are prime candidates because they carry institutional authority and their
+inaccuracy is especially newsworthy.
+
+Aim for 4–8 claims per report. Too few and the section feels thin; too many and it becomes
+a laundry list.
+
+## 2. Evaluating Evidence
+
+For each claim, gather:
+
+- **Primary sources**: Court filings, official press releases, video evidence, physical
+  evidence, sworn testimony, government databases
+- **Secondary sources**: Reporting from outlets that did original investigation (not wire
+  rewrites)
+- **Witness accounts**: Named witnesses, on-record interviews
+- **Expert analysis**: Legal experts, policy analysts, subject-matter specialists
+
+Hierarchy of evidence (strongest to weakest):
+1. Physical evidence (bullet holes, video, forensic results)
+2. Multiple independent witnesses with consistent accounts
+3. **Court filings and judicial findings** — these are exceptionally strong because judges
+   evaluate evidence under legal standards. A preliminary injunction requires a finding that
+   the plaintiff is "likely to succeed on the merits." A judicial opinion stating "the
+   government's claim is not supported by the record" is a factual determination, not editorial
+   opinion. Always cite the specific case number, judge name, and ruling date.
+4. Government records and databases
+5. Single-source witness accounts
+6. Expert opinion
+7. Unnamed/anonymous sources
+
+**MANDATORY: Search for judicial findings before finalizing verdicts.** For any claim involving
+government action or policy, check whether courts have ruled on the claim's validity. A judge's
+finding supersedes competing media narratives because it reflects adversarial testing of evidence.
+If a court has issued a ruling relevant to a claim under review, that ruling MUST be cited in the
+evidence section — regardless of whether media outlets reported on it. See the skill workflow
+Step 2 for the full primary-source research protocol.
+
+## 3. Assigning Verdicts
+
+Use these verdict categories:
+
+| Verdict | When to Use | Tag |
+|---------|------------|-----|
+| **FALSE** | Evidence clearly and directly contradicts the claim | [FALSE] |
+| **MISLEADING** | Claim contains a kernel of truth but omits critical context that changes the meaning | [MISLEADING] |
+| **UNSUBSTANTIATED** | No credible evidence supports the claim, but also no evidence directly disproves it | [UNSUBSTANTIATED] |
+| **EVIDENCE CONTRADICTS** | Multiple lines of evidence are inconsistent with the claim, but not a clean falsification | [EVIDENCE CONTRADICTS] |
+| **TRUE** | Evidence clearly supports the claim | [TRUE] |
+| **MOSTLY TRUE** | Claim is substantially accurate but contains minor errors or omissions | [MOSTLY TRUE] |
+| **DISPUTED** | Credible evidence exists on both sides; reasonable people disagree | [DISPUTED] |
+
+**No emoji.** Use the bracketed text tags above, not emoji symbols. The PDF is a first-class
+output and emoji do not render correctly in ReportLab.
+
+Be precise about which verdict applies. "FALSE" means the evidence directly contradicts the
+claim — don't use it when "MISLEADING" or "EVIDENCE CONTRADICTS" is more accurate. Overstating
+verdicts undermines the report's credibility.
+
+## 4. Claim Extraction (Before Writing Any Verdict)
+
+**This step is mandatory and must be completed before writing any fact-check entry.**
+
+For each claim under review, extract every discrete factual assertion made about the event
+from every article in the dataset that discusses it — regardless of outlet political orientation.
+Record these as a flat list of assertions with article IDs.
+
+Example: If reviewing a claim about a confrontation, the extraction might yield:
+- "Subject kicked the vehicle, breaking the tail light" (A28b, A34b, A39a)
+- "Agents tackled the subject" (A11b, A42a)
+- "Subject suffered a broken rib" (A11b, A37a)
+- "Subject yelled profanity at agents" (A28b, A34b, A37b)
+- "Subject spat toward agents" (A28b, A39a)
+
+This prevents inheriting the omissions of whichever cluster of outlets you happen to
+synthesize from first. The fact-check for a [MISLEADING] verdict should reflect ALL
+assertions, not just the ones surfaced by the sources you instinctively trust more.
+
+### Adversarial completeness check
+
+After extraction, explicitly answer these two questions:
+
+1. **What does the right-leaning coverage include that the left-leaning coverage omits?**
+2. **What does the left-leaning coverage include that the right-leaning coverage omits?**
+
+If either answer is non-trivial, the fact-check MUST address both omissions. A fact-check
+that only calls out one side's omission while silently reproducing the other side's omission
+is itself misleading — and undermines the report's credibility as a neutral analysis.
+
+### Primary source limitation flag
+
+When a fact-check hinges on video, audio, or other non-textual evidence that cannot be
+directly reviewed (because the analyst is working from textual descriptions, not viewing
+the media directly):
+
+1. Reconcile descriptions of the evidence from at least 3 outlets across different political
+   orientations before writing the verdict
+2. Note any details that appear in some outlets' descriptions but not others — these are
+   the most likely sites of selective framing
+3. If competing descriptions are irreconcilable without viewing the primary source, flag
+   this explicitly in the evidence section
+
+## 5. Structuring Each Claim
+
+Each fact-check entry should follow this structure:
+
+### Claim: "[The claim as stated]"
+
+**As stated:** How the claim was articulated, by whom, in what outlets. Include direct quotes
+where possible. Cite specific article IDs.
+
+**What the evidence shows:** Present the evidence that bears on the claim. Lead with the
+strongest evidence. Be specific — "video evidence" is weaker than "city surveillance video
+from the 600 block of 24th Ave N, timestamped 6:47 PM." Include assertions from across
+the political spectrum identified during claim extraction (Section 4).
+
+**Verdict: [TAG] [VERDICT]** — One-sentence summary of why this verdict applies. Use bracketed
+text tags (e.g., `[FALSE]`, `[MISLEADING]`) — no emoji.
+
+**Sources:** List the article IDs that contain the evidence, as clickable links.
+
+## 6. The Summary Table
+
+After all individual fact-checks, include a summary table:
+
+| # | Claim | Verdict | Key Evidence |
+|---|-------|---------|-------------|
+| 1 | [Short version] | [Symbol + word] | [One-line evidence summary] |
+
+This gives readers a quick overview before diving into details.
+
+## 7. Principles
+
+- **Cite article IDs** from the dataset, not just outlet names. This lets readers click through
+  to the actual source articles and cross-reference with the sentiment data.
+- **Don't editorialize.** The evidence should speak for itself. "Verdict: ❌ FALSE — no weapon
+  found" is better than "Verdict: ❌ FALSE — this was an outrageous lie."
+- **Include claims that turn out TRUE.** If a contested claim is actually supported by evidence,
+  say so. This demonstrates the analysis is evenhanded, not advocacy.
+- **Distinguish between the claim and the claimer.** A claim can be false even if the person
+  who made it believed it. Focus on the claim's accuracy, not the claimer's intent.
+- **Acknowledge uncertainty.** If the evidence is incomplete or ambiguous, say so. "DISPUTED"
+  is a legitimate verdict.

--- a/skills/media-coverage-analysis/references/report-structure.md
+++ b/skills/media-coverage-analysis/references/report-structure.md
@@ -1,0 +1,196 @@
+# Report Structure
+
+This document defines the exact section ordering, content expectations, and formatting
+for both the Markdown and PDF versions of the report.
+
+## Report Title and Header
+
+```markdown
+# Media Coverage & Sentiment Analysis Report
+
+## [Topic Title]
+
+**Report Date:** [Date] | **Topic Window:** [Start] – [End]
+```
+
+## Section Order — Required Minimum Structure
+
+The following 12 sections and 2 appendices are the **required minimum**. They must appear in
+this exact order and with these exact numbering/titles. Sections may be expanded with
+additional subsections but never removed, renamed, or reordered.
+
+### 1. Executive Summary
+
+2–3 paragraphs covering:
+- What happened (the core event)
+- Why it matters for media analysis (the divergence, the shift, the pattern)
+- The key finding (what the data shows about how coverage evolved)
+
+Keep it tight. The reader should understand the story and the report's value in under 60 seconds.
+
+### 2. Timeline of Key Events
+
+- Embed `chart_timeline.png`
+- Follow with a Markdown table: Date | Event
+- Include 8–15 key events spanning the topic window
+- Events should include: the triggering event, government responses, evidence emergence,
+  media inflection points, legal developments (court filings, judicial rulings, executive
+  orders, agency directives — with case numbers and judge names where applicable)
+- **Include government social media:** Presidential tweets/truths, cabinet-level social media
+  posts, and official government rhetoric that shaped the narrative environment — even if
+  they predate the topical event (e.g., inflammatory rhetoric posted the day before an
+  operation begins). These provide context for how coverage was primed.
+- Note: Government social media appears in the timeline (Section 2) but does NOT appear in
+  the sentiment analysis (Sections 4–5), which is limited to published articles after the
+  topical event date.
+
+### 3. Sentiment & Sentimental Narrative
+
+Analysis by political category. Use these subsections:
+
+- **The Right / Conservative Narrative** — initial framing, far-right vs. mainstream-right
+  divergence, shifts over time
+- **The Left / Progressive Narrative** — initial framing, consistency or evolution
+- **The Center / Mainstream Narrative** — initial framing, how it shifted as evidence emerged
+- **The Libertarian Narrative** — framing through the lens of government overreach / civil
+  liberties (if applicable)
+- **The Localist / Regional Narrative** — local outlets' unique perspective (if applicable)
+
+For each category, describe: the initial framing, the sentimental register (what emotion the
+article evokes), specific outlets and their approaches, and any shifts over time. Use specific
+article examples and quote headlines.
+
+### 4. Sentiment Map & Shift Over Time
+
+- Embed `chart_sentiment_shift.png`
+- Explain the chart: axes, what points represent, what size/opacity encode, what arrows mean
+- Describe marker shapes and colors
+- List 4–6 key observations from the chart
+- Reference Appendix A for the full article list
+
+### 5. Timeline & Alignment with Government Narrative
+
+- Embed `chart_combined_timeline_shift.png`
+- Explain the methodology: latest-per-outlet averaging, one point per date per category
+- Note the alignment formula: (1 − sentiment) / 2
+- Highlight key drops or sustained alignment
+- Reference Appendix B for per-article scores
+
+### 6. Coverage Volume by Source Type
+
+- Embed `chart_coverage_volume.png`
+- Brief description of the distribution
+
+### 7. Narrative Framing by Political Category
+
+- Embed `chart_framing.png`
+- Describe what the framing dimensions measure and key differences between categories
+- **Standard category order (left-to-right on x-axis):** Far Left, Left, Center-Left, Center,
+  Center-Right, Right, Far Right, Libertarian. Libertarian appears last as a cross-spectrum
+  outlier. This order is fixed across all reports for consistency.
+
+### 8. Public Sentiment Indicators
+
+Bullet points of available public opinion data:
+- Polls (with source and date)
+- Social media indicators
+- Protest/public action data
+- Celebrity/cultural involvement
+- Any other public sentiment signals
+
+This section uses whatever data is available; it's inherently less structured than the
+article-level analysis.
+
+### 9. Methodology Note
+
+Brief paragraph covering:
+- Report compilation date
+- Number of outlets and articles
+- Source of political-leaning baselines
+- Nature of the scoring (qualitative with explicit rubric, not algorithmic)
+- Primary legal/policy sources consulted (court filings, judicial rulings, executive orders,
+  agency directives — with case counts and specific case names)
+- Any caveats
+
+### 10. Fact-Check Section
+
+Follow the structure in `fact-checking-guide.md`:
+- Section header: "Fact-Check: Key Claims in Media Coverage"
+- Introductory paragraph explaining the purpose
+- 4–8 individual claim entries (each with Claim → As stated → Evidence → Verdict → Sources)
+- Sources should use article IDs with clickable links
+- Summary table at the end
+
+### 11. Appendix A: Sentiment Scoring Rubric & Source Articles
+
+- Scoring rubric (the 4-criterion table from `scoring-rubric.md`)
+- Full article table with columns: ID | Date | Outlet | x (pol) | y (sent) | Scores | Headline | Link
+- Sorted by political orientation (left to right), then by date
+- Headlines should be clickable links to the source URL
+- Every article in the dataset must appear here
+
+### 12. Appendix B: Government Narrative Alignment — Basis Data
+
+- Explanation of the alignment formula and methodology
+- Interpretation table (sentiment → alignment → interpretation)
+- Full article table with columns: ID | Date | Outlet | Category | Sent. | Align.
+- Article IDs should be clickable links
+- Sorted by date
+- Only includes articles on or after the topical event date
+- Government/official sources excluded (they define the narrative)
+
+## PDF-Specific Requirements
+
+**The PDF is a first-class output.** It is not a secondary artifact of the Markdown — it must
+be independently complete, professional, and correctly formatted. Every feature in the report
+must render correctly in the PDF. If a feature does not render in ReportLab (e.g., emoji
+characters), **do not use it** — find a text-only alternative. Specifically:
+
+- **No emoji in any output.** Use text labels like `[FALSE]`, `[MISLEADING]`, `[TRUE]` instead
+  of `❌`, `⚠️`, `✅`. This applies to both the Markdown and the PDF to keep them consistent.
+- Use `--` or `[X]` style markers instead of Unicode symbols that may not render.
+
+The PDF is generated using ReportLab's SimpleDocTemplate with Platypus flowables.
+
+### Links
+
+All of these must be clickable in the PDF:
+- Headlines in Appendix A → link to source URL
+- Article IDs in Appendix B → link to source URL
+- Article IDs in fact-check sources → link to source URL
+
+Use ReportLab's `<a href="url" color="#1a0dab">text</a>` syntax within Paragraph objects
+for links. The color `#1a0dab` is Google's link blue.
+
+### Page Breaks
+
+Insert page breaks:
+- Before the timeline + alignment chart section
+- Before the framing section
+- Before the fact-check section
+- Before Appendix A
+- Before Appendix B
+
+### Table Chunking
+
+For large tables (Appendix A with 50+ rows), split into chunks of ~13 rows per table
+to prevent overflow. For Appendix B, use chunks of ~18 rows.
+
+### Chart Sizing
+
+| Chart | Width | Height |
+|-------|-------|--------|
+| Timeline | 6.8in | 3.5in |
+| Sentiment shift | 6.8in | 4.5in |
+| Combined timeline+alignment | 6.8in | 4.2in |
+| Coverage volume pie | 4.5in | 4.5in |
+| Framing bar | 6.5in | 4.0in |
+
+### Styles
+
+Use a consistent style set:
+- Title: Helvetica-Bold 22pt
+- H1: Helvetica-Bold 16pt, #1a237e (dark blue)
+- H2: Helvetica-Bold 12pt, #333333
+- Body: Helvetica 9pt, leading 13, #333333
+- Small/source note: Helvetica 7pt, #666666, italic

--- a/skills/media-coverage-analysis/references/scoring-rubric.md
+++ b/skills/media-coverage-analysis/references/scoring-rubric.md
@@ -1,0 +1,157 @@
+# Scoring Rubric
+
+This document defines how to score articles for sentiment and political orientation. Consistency
+depends on applying these rules the same way across every article, regardless of whether you
+agree with the article's perspective.
+
+## 1. Sentiment Toward Subject (y-axis): –1.0 to +1.0
+
+Score each article on four observable criteria, each –0.25 to +0.25. Sum all four for the
+overall sentiment score. This produces a range of –1.0 to +1.0.
+
+### Criterion 1: Subject Description
+
+How the primary subject of the story is named and characterized in the headline and lede.
+
+| Score | Indicator |
+|-------|-----------|
+| –0.25 | Dehumanizing or criminalizing language in headline/lede: "illegal alien," "criminal," "violent," "gang member" without qualification |
+| –0.15 | Criminalizing language in body but not headline; headline neutral but lede foregrounds status |
+| –0.10 | Mild negative framing: "undocumented immigrant" with "charged with" or "accused of" leading |
+| 0.00 | Neutral: name + nationality stated factually, no characterization |
+| +0.10 | Mild positive context: mentions occupation, family, community ties |
+| +0.15 | Humanizing detail prominent: "father of two," "resident," "delivery driver" |
+| +0.20 | Victim framing in headline: "man shot by" rather than "man involved in" |
+| +0.25 | Strongly sympathetic framing: "victim," humanizing headline, no criminalizing language |
+
+### Criterion 2: Account Primacy
+
+Whose version of events leads the article and structures the narrative.
+
+| Score | Indicator |
+|-------|-----------|
+| –0.25 | Government/official account leads and structures article; defense/victim account buried or absent |
+| –0.15 | Government account leads but defense mentioned by paragraph 3–5 |
+| –0.10 | Government account in headline; both accounts in body with slight govt emphasis |
+| 0.00 | Both accounts presented with roughly equal prominence and space |
+| +0.10 | Defense/victim account in headline; government account in body |
+| +0.15 | Defense/victim account leads; government account mentioned but challenged |
+| +0.20 | Defense/victim account structures the article; government account presented as contested |
+| +0.25 | Defense/victim account leads; government account explicitly challenged or debunked |
+
+### Criterion 3: Emotional Register
+
+The affective tone and moral framing of the article.
+
+| Score | Indicator |
+|-------|-----------|
+| –0.25 | Indignation toward subject; sympathy exclusively for officers/officials; outrage framing |
+| –0.15 | Officers presented as victims; subject's situation minimized |
+| –0.10 | Slight rhetorical sympathy for official position; subject treated as problem |
+| 0.00 | Procedural, detached, wire-service tone |
+| +0.10 | Slight rhetorical concern for subject's situation |
+| +0.15 | Empathy for subject visible; concern about overreach |
+| +0.20 | Outrage on behalf of subject; strong empathy framing |
+| +0.25 | Moral condemnation of official actions; full solidarity framing |
+
+### Criterion 4: Identity/Status Foregrounding
+
+How prominently the subject's identity characteristics (immigration status, race, nationality,
+criminal record, etc.) are used as a framing device versus contextual detail.
+
+This criterion adapts to the topic. For immigration stories, it's about immigration status
+foregrounding. For police use-of-force stories involving race, it might be about how race
+is foregrounded. For corporate scandals, it might be about how the executive's wealth is
+framed. The principle is the same: does the article use identity as a framing device to
+shape the reader's reaction?
+
+| Score | Indicator |
+|-------|-----------|
+| –0.25 | Identity/status foregrounded in headline as primary framing device |
+| –0.15 | Identity/status in headline but not sole framing device |
+| –0.10 | Identity/status mentioned in lede as relevant context |
+| 0.00 | Identity/status mentioned in body, neutral context |
+| +0.05 | Identity/status mentioned but de-emphasized |
+| +0.10 | Identity/status present but buried; irrelevant to framing |
+| +0.15 | Identity/status omitted from framing; other details emphasized |
+| +0.20 | Identity/status explicitly challenged as irrelevant framing |
+| +0.25 | Identity/status omitted entirely or actively de-emphasized |
+
+### Score Breakdown Format
+
+Record scores as a slash-separated string: `"+.25/+.20/+.15/+.10"` representing
+subj/prim/reg/stat. This makes it auditable — anyone can check which criteria drove the score.
+
+### Calibration Guide
+
+| Overall Score Range | Interpretation | Example |
+|---------------------|----------------|---------|
+| +0.75 to +1.00 | Strongly sympathetic | Full solidarity framing, subject is victim, officials condemned |
+| +0.25 to +0.75 | Moderately sympathetic | Subject humanized, defense account leads, concern for subject |
+| –0.25 to +0.25 | Neutral / balanced | Wire-service tone, both accounts presented, minimal framing |
+| –0.75 to –0.25 | Moderately hostile | Official account leads, criminalizing language, subject as problem |
+| –1.00 to –0.75 | Strongly hostile | Full government narrative, criminalizing headline, subject dehumanized |
+
+## 2. Political Orientation (x-axis): –3.0 to +3.0
+
+Use AllSides and Ad Fontes Media ratings as baselines for each outlet's general editorial
+positioning. Then adjust ±0.3 maximum based on this specific story's framing.
+
+### Baseline Spectrum
+
+| x Range | Category | Example Outlets |
+|---------|----------|----------------|
+| –3.0 to –2.0 | Far Left | The Intercept, Common Dreams, Jacobin |
+| –2.0 to –1.5 | Left | Salon, Daily Beast, Mother Jones, MN Reformer |
+| –1.5 to –0.5 | Center-Left | NPR, PBS, CNN, WaPo, Slate, MPR, Sahan Journal |
+| –0.5 to +0.5 | Center | AP, CBS, NBC, ABC, Reuters, KARE 11, KTTC, Fox 9 |
+| +0.5 to +1.0 | Center-Right | Free Press, WSJ editorial |
+| +1.0 to +2.0 | Right | Fox News, Nat'l Review, Wash Times, Daily Caller |
+| +2.0 to +2.5 | Far Right | Daily Wire, Newsmax, Federalist |
+| +2.5 to +3.0 | Extreme Right | Breitbart, OANN |
+| +1.0 (approx) | Libertarian | Reason, Cato Institute |
+| +2.5 (for govt) | Government | DHS, DOJ, White House press releases |
+
+### Story-Specific Adjustments (±0.3 max)
+
+- If an outlet's coverage of this specific story is notably more partisan than their baseline,
+  adjust up to ±0.3
+- Document the adjustment rationale
+- Never adjust more than ±0.3 from baseline — if coverage seems wildly off-baseline, double-check
+  that you have the outlet identified correctly
+
+### Outlet Categories for Charting
+
+Assign each outlet a category string for marker shape/color grouping:
+`left`, `center-left`, `center`, `center-right`, `right`, `libertarian`, `gov`
+
+### Broad Categories for Alignment Chart
+
+For the government narrative alignment traces, group outlets into 6 categories:
+
+| Broad Category | Rule |
+|---------------|------|
+| Far-Right | `cat == 'right'` and `x >= 2.3` |
+| Right | `cat == 'right'` and `x < 2.3` |
+| Center | `cat in ('center', 'center-right')` |
+| Center-Left | `cat == 'center-left'` |
+| Left | `cat == 'left'` |
+| Libertarian | `cat == 'libertarian'` |
+
+Government/official sources are excluded from the alignment traces (they define the narrative,
+they don't align with it).
+
+## 3. Consistency Principles
+
+- **Score what you observe**, not what you infer. If an article uses neutral language but you
+  know the outlet is partisan, score the language, not the outlet.
+- **Score each criterion independently.** An article can have hostile subject description but
+  neutral account primacy (e.g., if it uses "illegal alien" in the headline but quotes both
+  sides equally).
+- **When uncertain, score toward 0.** A score of 0.00 means "I couldn't determine a clear lean"
+  — this is better than guessing.
+- **Re-score if needed.** If after scoring 20 articles you realize your calibration drifted,
+  go back and adjust. Internal consistency matters more than getting every score perfect on
+  first pass.
+- **The subscores must sum to the overall score.** This is a hard constraint. If you want an
+  overall score of +0.55, you need subscores that add to +0.55.

--- a/skills/media-coverage-analysis/requirements.txt
+++ b/skills/media-coverage-analysis/requirements.txt
@@ -1,0 +1,3 @@
+matplotlib
+numpy
+reportlab

--- a/skills/media-coverage-analysis/scripts/TEMPLATE_USAGE.md
+++ b/skills/media-coverage-analysis/scripts/TEMPLATE_USAGE.md
@@ -1,0 +1,253 @@
+# Media Coverage Analysis Template Scripts
+
+This directory contains three generalized template scripts adapted from the working Sosa-Celis media coverage analysis report. Each script has been refactored to isolate topic-specific configuration at the top, while preserving the exact working logic from the original implementations.
+
+## Scripts Overview
+
+### 1. `generate_charts_template.py` (19 KB)
+
+**Purpose:** Generate the five core charts for media coverage analysis.
+
+**Produces:**
+- `chart_timeline.png` - Event timeline with vertical positioning
+- `chart_sentiment_scatter.png` - Outlet positioning by political leaning vs. sentiment
+- `chart_combined_timeline_shift.png` - Timeline + government narrative alignment trace
+- `chart_coverage_volume.png` - Pie chart of coverage distribution
+- `chart_framing.png` - Bar chart of framing emphasis by political category
+
+**Configuration Section:**
+- Output directory path
+- Color palette (optional customization)
+- Time axis limits (COMMON_XLIM for overview, EVENT_XLIM for detail)
+- Event list: `(date, label, side, category_key)` tuples
+- Position magnitudes for timeline labels
+- Outlet data: `(name, ID, x_political, y_sentiment, category)` tuples
+- Coverage volume pie chart: labels and sizes
+- Framing emphasis data: 4 dimensions across 8 political categories
+
+**Working Logic Preserved:**
+- Timeline drawing with alternating event positioning
+- Sentiment scatter with category-specific markers and colors
+- Article-based government narrative alignment calculation (reads from `article_data.py`)
+- Pie chart rendering with auto-percentages
+- Multi-series bar chart with proper spacing and labeling
+- All matplotlib styling (colors, fonts, sizes, spines)
+
+**Dependencies:**
+- `matplotlib`
+- `numpy`
+- `article_data.py` (optional; Chart 3 gracefully skips if missing)
+
+---
+
+### 2. `generate_shift_chart_template.py` (9.0 KB)
+
+**Purpose:** Generate the article-level sentiment shift chart showing trajectory over time.
+
+**Produces:**
+- `chart_sentiment_shift.png` - Article positions with opacity/size encoding recency, arrows showing shifts
+
+**Configuration Section:**
+- `ARTICLE_DATA_DIR` - Path to directory containing `article_data.py`
+- `OUT` - Output directory for the chart
+
+**Working Logic Preserved:**
+- Date-to-alpha mapping (older = faded, newer = opaque)
+- Date-to-size mapping (older = small, newer = large)
+- Arrow drawing between consecutive articles from same outlet
+- Chronological shift visualization with color coding per outlet category
+- Latest-article labeling (prominent) + earliest-article labeling (faint)
+- Quadrant labels and explanation text
+- Full legend with marker shapes
+
+**Dependencies:**
+- `matplotlib`
+- `article_data.py` (required; contains ARTICLES, OUTLET_X, OUTLET_CAT)
+
+---
+
+### 3. `generate_pdf_template.py` (26 KB)
+
+**Purpose:** Generate comprehensive PDF report with all charts, fact-checks, and appendices.
+
+**Produces:**
+- PDF report with the following sections:
+  1. Title page + Executive Summary
+  2. Timeline of key events (table + chart)
+  3. Narrative framing by political category (5 sections)
+  4. Sentiment map and shift analysis
+  5. Combined timeline + alignment chart
+  6. Coverage volume and framing charts
+  7. Public sentiment indicators table
+  8. Methodology section
+  9. Fact-check section (claims, evidence, verdicts with clickable article links)
+  10. Appendix A: Scoring rubric and article-level data table
+  11. Appendix B: Alignment formula and per-article alignment scores
+
+**Configuration Section:**
+- `ARTICLE_DATA_DIR` - Path to `article_data.py`
+- `OUT` - Output directory for PDF
+- `TOPIC_TITLE` - Main title for the report
+- `REPORT_DATE` - Publication date
+- `TOPIC_WINDOW` - Time period covered
+- `PDF_FILENAME` - Output filename
+- `EXECUTIVE_SUMMARY` - Brief overview (with HTML formatting support)
+- `TIMELINE_EVENTS` - List of `[date_str, description]` pairs
+- `NARRATIVE_SECTIONS` - List of `(section_title, body_html)` tuples (5 sections)
+- `PUBLIC_SENTIMENT_DATA` - Table data: `[indicator, finding, source]` rows
+- `FACT_CHECKS` - List of `(title, claim_text, evidence_text, verdict_text, source_aids)` tuples
+- `FACT_CHECK_SUMMARY` - Summary table data
+- `RUBRIC_CRITERIA` - Scoring rubric rows
+- `ALIGNMENT_FORMULA` - Formula interpretation table
+
+**Working Logic Preserved:**
+- ReportLab document structure and styling
+- Table generation with alternating row colors
+- Image embedding (graceful fallback to spacer if missing)
+- Hyperlink generation from article ID to URL (via `article_data.py`)
+- Government alignment calculation: `(1 - sentiment) / 2`
+- Broad category classification logic
+- Page breaks for proper section separation
+- Font styling, colors, and spacing exactly as in original
+
+**Dependencies:**
+- `reportlab`
+- `article_data.py` (required)
+
+---
+
+## How to Use These Templates
+
+### Step 1: Prepare Your Article Data
+Create an `article_data.py` file with your topic data:
+
+```python
+# article_data.py
+from datetime import datetime
+
+# List of all articles as tuples:
+# (outlet, article_id, date, sentiment_y, headline, url, scores_description)
+ARTICLES = [
+    ("Outlet Name", "A1", datetime(2026, 1, 15), 0.75, "Article Headline", "https://...", "0.25+0.25+0.25+0.00"),
+    # ... more articles
+]
+
+# Dict mapping outlet name to x-axis political position
+OUTLET_X = {
+    "Outlet Name": -1.5,
+    # ... more outlets
+}
+
+# Dict mapping outlet name to category
+OUTLET_CAT = {
+    "Outlet Name": "center-left",
+    # ... more outlets
+}
+```
+
+### Step 2: Configure Each Template
+Fill in the CONFIGURATION section at the top of each script:
+
+**For `generate_charts_template.py`:**
+- Set `OUT` to your output directory
+- Define your `events` list
+- Set `COMMON_XLIM` and `EVENT_XLIM`
+- Provide `outlets` list with all sources
+- Update pie chart data and framing emphasis arrays
+
+**For `generate_shift_chart_template.py`:**
+- Set `ARTICLE_DATA_DIR` and `OUT`
+
+**For `generate_pdf_template.py`:**
+- Set `ARTICLE_DATA_DIR`, `OUT`, and metadata fields
+- Write `EXECUTIVE_SUMMARY`, `NARRATIVE_SECTIONS`, fact-checks, etc.
+- Optionally customize rubric and formula interpretation tables
+
+### Step 3: Run the Scripts
+```bash
+python generate_charts_template.py
+python generate_shift_chart_template.py
+python generate_pdf_template.py
+```
+
+Charts are generated first (required for PDF). Then PDF can embed them.
+
+---
+
+## Key Design Decisions
+
+### Configuration Isolation
+All topic-specific values are clustered at the top of each script, clearly marked with decorative section headers. The rest of the code remains untouched from the Sosa-Celis originals.
+
+### Preserved Logic
+Every chart algorithm, color scheme, font setting, and layout decision has been preserved exactly:
+- Matplotlib figure sizes, DPI, styling
+- Color hex values and category mappings
+- Event positioning magnitudes
+- Alpha/size date-encoding functions
+- ReportLab styling, spacing, font choices
+- Table borders, backgrounds, padding
+- Hyperlink generation from article data
+
+### Graceful Fallbacks
+- `generate_charts_template.py` gracefully skips Chart 3 if `article_data.py` is not found
+- `generate_pdf_template.py` exits cleanly with an error message if article data is missing
+- Images are embedded only if they exist; otherwise, spacers are used
+
+### Extensibility
+The templates can be easily extended:
+- Add more events to the timeline
+- Add more outlets to the sentiment scatter
+- Add more narrative sections to the PDF
+- Adjust color palettes and font sizes in the configuration
+- Modify rubric criteria or fact-check claims
+
+---
+
+## File Sizes
+- `generate_charts_template.py` - 19 KB (5 charts)
+- `generate_shift_chart_template.py` - 9.0 KB (1 chart)
+- `generate_pdf_template.py` - 26 KB (comprehensive report)
+
+**Total:** ~54 KB of template code for a complete media coverage analysis pipeline.
+
+---
+
+## Example Workflow
+
+```bash
+# 1. Create article_data.py in your working directory
+# 2. Customize and run the chart generator
+python generate_charts_template.py
+
+# 3. Run the shift chart generator
+python generate_shift_chart_template.py
+
+# 4. Run the PDF generator (it will embed the charts)
+python generate_pdf_template.py
+
+# 5. Output files:
+#    - chart_timeline.png
+#    - chart_sentiment_scatter.png
+#    - chart_combined_timeline_shift.png
+#    - chart_coverage_volume.png
+#    - chart_framing.png
+#    - chart_sentiment_shift.png
+#    - YourTopic_Media_Coverage_Report.pdf
+```
+
+---
+
+## Notes
+
+- All sentiment/alignment calculations assume y-axis ranges from -1 (hostile) to +1 (sympathetic)
+- Political orientation (x-axis) ranges from -3 (far left) to +3 (far right)
+- Dates must be Python `datetime` objects
+- URLs in article_data.py become clickable links in the PDF (via `aid_link()` function)
+- All configuration uses clear variable names; no magic numbers outside the config section
+
+---
+
+**Generated from:** `/sessions/bold-trusting-edison/generate_charts.py`, `generate_shift_charts.py`, `generate_pdf_v3.py`
+
+**Template created:** February 15, 2026

--- a/skills/media-coverage-analysis/scripts/generate_charts_template.py
+++ b/skills/media-coverage-analysis/scripts/generate_charts_template.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""
+Generate charts for media coverage analysis — Template.
+Adapted from the working Sosa-Celis report to be generalized for any topic.
+
+This template produces five charts:
+  1. Timeline of key events
+  2. Sentiment scatter (outlets positioned by political leaning and sentiment)
+  3. Combined timeline + government narrative alignment
+  4. Coverage volume (pie chart)
+  5. Framing emphasis (bar chart by category)
+
+INSTRUCTIONS: Fill in the CONFIGURATION section below with your topic-specific data,
+then run this script. All chart logic and styling remain unchanged.
+"""
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import matplotlib.patches as mpatches
+import matplotlib.dates as mdates
+from datetime import datetime
+import numpy as np
+import os
+
+# ════════════════════════════════════════════════════════════════════════════
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║                        CONFIGURATION SECTION                             ║
+# ║  Customize the following values for your topic. Everything else remains  ║
+# ║  unchanged and uses the exact logic from the Sosa-Celis working report.  ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+# ════════════════════════════════════════════════════════════════════════════
+
+# Output directory for charts
+OUT = "/path/to/your/output/directory"
+os.makedirs(OUT, exist_ok=True)
+
+# Color palette (customize if desired)
+LEFT_C = '#2171b5'
+CENTER_C = '#6a51a3'
+RIGHT_C = '#cb181d'
+LIBERT_C = '#f59e0b'
+GOV_C = '#525252'
+NEUTRAL_C = '#737373'
+SHOOTING_C = '#e31a1c'
+EVIDENCE_C = '#2ca02c'
+INFO_C = '#1f77b4'
+
+# Time axis limits for Chart 1 (timeline overview)
+COMMON_XLIM = (datetime(2025, 11, 25), datetime(2026, 2, 20))
+
+# Time axis limits for Chart 3 (combined timeline+alignment, typically narrower)
+# Usually starts at the primary topical event
+EVENT_XLIM = (datetime(2026, 1, 12), datetime(2026, 2, 16))
+
+# Define key events as a list of tuples:
+# (date, label, side, category_key)
+# where:
+#   - date: datetime object
+#   - label: Multi-line text for annotation (use \n)
+#   - side: +1 (positive/upper) or -1 (negative/lower) on timeline
+#   - category_key: 'gov' | 'shoot' | 'evidence' | 'info'
+events = [
+    (datetime(2025, 12, 1),  "Operation Metro\nSurge begins",                  -1, 'gov'),
+    (datetime(2026, 1, 7),   "Renée Good\nfatally shot",                       1,  'shoot'),
+    (datetime(2026, 1, 14),  "Sosa-Celis shot\nby ICE agent",                  -1, 'shoot'),
+    (datetime(2026, 1, 15),  "DHS labels victims\n'violent criminals'",         1,  'gov'),
+    (datetime(2026, 1, 16),  "Bystander videos\nemerge",                       -1, 'evidence'),
+    (datetime(2026, 1, 24),  "Alex Pretti\nfatally shot",                      1,  'shoot'),
+    (datetime(2026, 1, 27),  "Conservative outlets\nbreak from narrative",      -1, 'evidence'),
+    (datetime(2026, 2, 5),   "Partner Indriany\nspeaks publicly",              1,  'info'),
+    (datetime(2026, 2, 13),  "ICE admits agents\n'untruthful'",                -1, 'evidence'),
+    (datetime(2026, 2, 14),  "Charges dismissed;\nperjury probe opened",        1,  'evidence'),
+]
+
+# Position magnitudes for events alternating vertically on timeline
+# These control the vertical spacing of event labels
+pos_mags = [2.0, 3.4, 4.5, 1.4, 2.8]
+neg_mags = [2.0, 3.4, 4.5, 1.4, 2.8]
+
+# Outlet data: (name, ID, x_political, y_sentiment, category)
+# x_political: -3.0 (far left) to +3.0 (far right)
+# y_sentiment: -1.0 (hostile) to +1.0 (sympathetic)
+# category: 'left' | 'center-left' | 'center' | 'center-right' | 'right' | 'libertarian' | 'gov'
+outlets = [
+    # Far Left
+    ("The Intercept",      "A1",  -2.8, 0.95, 'left'),
+    ("Common Dreams",      "A2",  -2.5, 0.9,  'left'),
+    ("Jacobin/Salon",      "A3",  -2.2, 0.85, 'left'),
+    # Left
+    ("The Daily Beast",    "A4",  -1.8, 0.85, 'left'),
+    ("Minnesota Reformer", "A5",  -1.5, 0.8,  'left'),
+    ("Mother Jones",       "A6",  -1.5, 0.8,  'left'),
+    # Center-Left
+    ("Slate",              "A7",  -1.2, 0.7,  'center-left'),
+    ("NPR",                "A8",  -1.0, 0.6,  'center-left'),
+    ("PBS NewsHour",       "A9",  -0.8, 0.55, 'center-left'),
+    ("CNN",                "A10", -0.7, 0.5,  'center-left'),
+    ("Washington Post",    "A11", -0.5, 0.5,  'center-left'),
+    ("Sahan Journal",      "A12", -0.5, 0.85, 'center-left'),
+    # Center
+    ("NBC News",           "A13", -0.3, 0.45, 'center'),
+    ("CBS News",           "A14", -0.2, 0.4,  'center'),
+    ("AP / Wire",          "A15",  0.0, 0.35, 'center'),
+    ("ABC News",           "A16", -0.2, 0.4,  'center'),
+    # Center-Right
+    ("The Free Press",     "A17",  0.5, 0.3,  'center-right'),
+    ("Reason",             "A18",  1.0, 0.35, 'libertarian'),
+    # Right
+    ("Fox News",           "A19",  1.8, -0.2, 'right'),
+    ("Washington Times",   "A20",  1.0, 0.0,  'right'),
+    ("National Review",    "A21",  1.8, -0.5, 'right'),
+    ("Daily Caller",       "A22",  2.0, -0.4, 'right'),
+    # Far Right
+    ("Daily Wire",         "A23",  2.3, -0.7, 'right'),
+    ("The Federalist",     "A24",  2.5, -0.8, 'right'),
+    ("Newsmax",            "A25",  2.3, -0.3, 'right'),
+    ("Breitbart",          "A26",  2.7, -0.5, 'right'),
+    ("OANN",               "A27",  2.8, -0.85,'right'),
+    # Government
+    ("DHS (official)",     "A28",  2.5, -0.9, 'gov'),
+]
+
+# Coverage volume pie chart data
+# Customize the labels and percentages for your topic
+pie_labels = ['Center-Left /\nMainstream', 'Left /\nProgressive', 'Right /\nConservative',
+              'Far Right', 'Local MN', 'Wire (AP)', 'Libertarian', 'Govt']
+pie_sizes = [30, 18, 10, 8, 18, 8, 4, 4]
+pie_colors = ['#4292c6', LEFT_C, RIGHT_C, '#800000', '#78c679', NEUTRAL_C, LIBERT_C, GOV_C]
+
+# Framing emphasis data (Chart 5)
+# Each row represents a political category; columns are emphasis levels (0-1)
+framing_categories = ['Far Left', 'Left', 'Center-Left', 'Center', 'Center-Right', 'Right', 'Far Right', 'Libertarian']
+framing_accountability =     [0.95, 0.90, 0.85, 0.70, 0.55, 0.25, 0.10, 0.70]
+framing_immigrant_sympathy = [0.95, 0.85, 0.70, 0.50, 0.30, 0.15, 0.05, 0.45]
+framing_govt_credibility =   [0.90, 0.85, 0.80, 0.75, 0.65, 0.40, 0.20, 0.85]
+framing_civil_liberties =    [0.85, 0.75, 0.65, 0.50, 0.40, 0.15, 0.05, 0.90]
+
+# ════════════════════════════════════════════════════════════════════════════
+# END CONFIGURATION — Below this line, no customization needed
+# ════════════════════════════════════════════════════════════════════════════
+
+plt.rcParams.update({
+    'figure.facecolor': '#fafafa', 'axes.facecolor': '#fafafa',
+    'font.family': 'sans-serif', 'font.size': 11,
+    'axes.titlesize': 14, 'axes.titleweight': 'bold',
+})
+
+color_map = {'gov': GOV_C, 'shoot': SHOOTING_C, 'evidence': EVIDENCE_C, 'info': INFO_C}
+legend_items = [
+    mpatches.Patch(color=SHOOTING_C, label='Shooting events'),
+    mpatches.Patch(color=GOV_C, label='Government actions'),
+    mpatches.Patch(color=EVIDENCE_C, label='Evidence / accountability'),
+    mpatches.Patch(color=INFO_C, label='Public / media events'),
+]
+
+def draw_timeline(ax, fontsize=8, markersize=9):
+    """Draw event timeline on axis. Uses global 'events' and 'pos_mags', 'neg_mags'."""
+    pi, ni = 0, 0
+    for date, label, side, ckey in events:
+        col = color_map[ckey]
+        if side > 0:
+            lvl = pos_mags[pi % len(pos_mags)]; pi += 1
+        else:
+            lvl = -neg_mags[ni % len(neg_mags)]; ni += 1
+        ax.plot([date, date], [0, lvl], color=col, linewidth=1.8, alpha=0.7)
+        ax.plot(date, lvl, 'o', color=col, markersize=markersize, zorder=5,
+                markeredgecolor='white', markeredgewidth=1)
+        va = 'bottom' if lvl > 0 else 'top'
+        y_off = 10 if lvl > 0 else -10
+        ax.annotate(label, xy=(date, lvl), xytext=(0, y_off),
+                    textcoords='offset points', ha='center', va=va,
+                    fontsize=fontsize, fontweight='bold', color=col,
+                    bbox=dict(boxstyle='round,pad=0.35', facecolor='white',
+                              edgecolor=col, alpha=0.92, linewidth=1.2))
+    ax.axhline(0, color='#aaaaaa', linewidth=2, zorder=1)
+
+
+# ═══════════════ CHART 1 — Standalone Timeline ═══════════════
+fig, ax = plt.subplots(figsize=(16, 9))
+draw_timeline(ax)
+ax.legend(handles=legend_items, loc='lower left', fontsize=9, framealpha=0.9, ncol=2)
+ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %d'))
+ax.xaxis.set_major_locator(mdates.WeekdayLocator(interval=1))
+ax.set_xlim(*COMMON_XLIM); ax.set_ylim(-5.8, 5.8); ax.set_yticks([])
+ax.set_title('Timeline: The Julio Cesar Sosa-Celis Story & Operation Metro Surge', pad=15, fontsize=15)
+for sp in ['top', 'right', 'left']: ax.spines[sp].set_visible(False)
+fig.tight_layout()
+fig.savefig(f'{OUT}/chart_timeline.png', dpi=150, bbox_inches='tight')
+plt.close(); print("✓ Timeline")
+
+
+# ═══════════════ CHART 2 — Sentiment Scatter (expanded sources) ═══════════════
+fig, ax = plt.subplots(figsize=(14, 9))
+
+cat_style = {
+    'left':         (LEFT_C,    's', 'Left / Far Left'),
+    'center-left':  ('#4292c6', 'D', 'Center-Left'),
+    'center':       (CENTER_C,  'o', 'Center'),
+    'center-right': ('#fb6a4a', 'D', 'Center-Right'),
+    'right':        (RIGHT_C,   '^', 'Right / Far Right'),
+    'libertarian':  (LIBERT_C,  'P', 'Libertarian'),
+    'gov':          (GOV_C,     'X', 'Government'),
+}
+
+for name, aid, x, y, cat in outlets:
+    c, m, _ = cat_style[cat]
+    ax.scatter(x, y, c=c, marker=m, s=140, zorder=5, edgecolors='white', linewidth=0.8)
+    ax.annotate(f"{name} [{aid}]", (x, y), textcoords="offset points", xytext=(9, -3),
+                fontsize=7, color=c, fontweight='bold')
+
+# ── Build marker legend ──
+from matplotlib.lines import Line2D
+legend_handles = []
+seen = set()
+for cat_key in ['left', 'center-left', 'center', 'center-right', 'right', 'libertarian', 'gov']:
+    c, m, lbl = cat_style[cat_key]
+    if lbl not in seen:
+        seen.add(lbl)
+        legend_handles.append(Line2D([0], [0], marker=m, color='w', markerfacecolor=c,
+                                     markeredgecolor='white', markersize=10, label=lbl))
+ax.legend(handles=legend_handles, loc='upper left', fontsize=8, framealpha=0.92,
+          title='Marker Legend', title_fontsize=9, borderpad=0.8, labelspacing=0.6)
+
+ax.axhline(0, color='#cccccc', linewidth=0.8, linestyle='--')
+ax.axvline(0, color='#cccccc', linewidth=0.8, linestyle='--')
+ax.set_xlabel('← Left-Leaning                    Political Orientation                    Right-Leaning →', fontsize=11)
+ax.set_ylabel('← Hostile to Subject         Sentiment Toward Sosa-Celis         Sympathetic →', fontsize=11)
+ax.set_title('Media Outlet Positioning: Political Leaning vs. Sentiment (28 Sources)', pad=15)
+ax.set_xlim(-3.5, 3.5); ax.set_ylim(-1.15, 1.15)
+ax.text(-3.0, 1.02, 'Left + Sympathetic', fontsize=8, color='#999', style='italic')
+ax.text(1.8, 1.02, 'Right + Sympathetic', fontsize=8, color='#999', style='italic')
+ax.text(-3.0, -1.08, 'Left + Hostile', fontsize=8, color='#999', style='italic')
+ax.text(2.0, -1.08, 'Right + Hostile', fontsize=8, color='#999', style='italic')
+ax.text(0.5, -0.015, 'Codes [A1]–[A28] → Appendix A for rubric, scores & article links',
+        transform=ax.transAxes, fontsize=8, color='#888888', style='italic', ha='center')
+ax.spines['top'].set_visible(False); ax.spines['right'].set_visible(False)
+fig.tight_layout()
+fig.savefig(f'{OUT}/chart_sentiment_scatter.png', dpi=150, bbox_inches='tight')
+plt.close(); print("✓ Sentiment scatter (28 sources)")
+
+
+# ═══════════════ CHART 3 — Combined Timeline + Narrative Alignment ═══════════════
+# Note: This chart requires ARTICLES data from article_data.py
+# If you have article_data.py in the same directory structure, it will load automatically.
+# Otherwise, this chart will be skipped with a message.
+
+try:
+    import sys
+    sys.path.insert(0, os.path.dirname(os.path.dirname(OUT)))
+    from article_data import ARTICLES, OUTLET_X, OUTLET_CAT
+    from collections import defaultdict
+
+    # Government narrative alignment = (1 - y_sentiment) / 2  →  maps [-1,+1] to [1,0]
+    def govt_alignment(y_sent):
+        return max(0, min(1, (1 - y_sent) / 2))
+
+    def broad_cat(outlet):
+        x = OUTLET_X[outlet]
+        cat = OUTLET_CAT[outlet]
+        if cat == 'gov': return 'Gov'
+        if cat == 'libertarian': return 'Libertarian'
+        if cat == 'left': return 'Left'
+        if cat in ('center-left',): return 'Center-Left'
+        if cat in ('center', 'center-right'): return 'Center'
+        if cat == 'right' and x >= 2.3: return 'Far-Right'
+        if cat == 'right': return 'Right'
+        return 'Center'
+
+    EVENT_START = datetime(2026, 1, 14)
+
+    traces = defaultdict(list)
+    for outlet, aid, date, y, headline, url, scores in ARTICLES:
+        if date < EVENT_START: continue
+        bc = broad_cat(outlet)
+        if bc == 'Gov': continue
+        traces[bc].append((outlet, date, govt_alignment(y)))
+
+    def build_latest_per_outlet_avg(points):
+        """Given list of (outlet, date, alignment), return (dates, avgs) bucketed by day."""
+        sorted_pts = sorted(points, key=lambda p: p[1])
+        from collections import OrderedDict
+        by_date = OrderedDict()
+        for outlet, d, v in sorted_pts:
+            if d not in by_date:
+                by_date[d] = []
+            by_date[d].append((outlet, v))
+        dates_out, avgs_out = [], []
+        latest = {}
+        for d, articles in by_date.items():
+            for outlet, v in articles:
+                latest[outlet] = v
+            avg = sum(latest.values()) / len(latest)
+            dates_out.append(d)
+            avgs_out.append(avg)
+        return dates_out, avgs_out
+
+    trace_styles = {
+        'Far-Right':    ('v-',  '#800000', 2.5, 7),
+        'Right':        ('o-',  RIGHT_C,   2.5, 7),
+        'Center':       ('s--', CENTER_C,  2.0, 6),
+        'Center-Left':  ('D--', '#4292c6', 2.0, 6),
+        'Left':         ('D:',  LEFT_C,    2.0, 6),
+        'Libertarian':  ('P-.', LIBERT_C,  2.0, 7),
+    }
+    trace_order = ['Far-Right', 'Right', 'Center', 'Center-Left', 'Left', 'Libertarian']
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(16, 10), sharex=True,
+                                    gridspec_kw={'height_ratios': [3, 2], 'hspace': 0.08})
+    draw_timeline(ax1, fontsize=7, markersize=7)
+    ax1.set_ylim(-5.8, 5.8); ax1.set_yticks([])
+    ax1.set_title('Timeline & Alignment with Government Narrative (Article-Based)', pad=12, fontsize=14)
+    for sp in ['top', 'right', 'left']: ax1.spines[sp].set_visible(False)
+    ax1.legend(handles=legend_items, loc='lower left', fontsize=8, framealpha=0.9, ncol=2)
+
+    for cat_name in trace_order:
+        if cat_name not in traces: continue
+        dates_t, avgs_t = build_latest_per_outlet_avg(traces[cat_name])
+        fmt, col, lw, ms = trace_styles[cat_name]
+        ax2.plot(dates_t, avgs_t, fmt, color=col, linewidth=lw, markersize=ms, label=cat_name, alpha=0.85)
+
+    for date, label, side, ckey in events:
+        if date >= datetime(2026, 1, 14):
+            ax2.axvline(date, color='#dddddd', linewidth=0.8, linestyle=':', zorder=0)
+
+    ax2.set_ylabel('Alignment with\nGovt Narrative', fontsize=10)
+    ax2.set_ylim(-0.05, 1.1)
+    ax2.xaxis.set_major_formatter(mdates.DateFormatter('%b %d'))
+    ax2.xaxis.set_major_locator(mdates.WeekdayLocator(interval=1))
+    ax2.set_xlim(*EVENT_XLIM)
+    ax1.set_xlim(*EVENT_XLIM)
+    ax2.legend(loc='upper right', fontsize=8, framealpha=0.9, ncol=2)
+    ax2.spines['top'].set_visible(False); ax2.spines['right'].set_visible(False)
+    fig.savefig(f'{OUT}/chart_combined_timeline_shift.png', dpi=150, bbox_inches='tight')
+    plt.close(); print("✓ Combined timeline+alignment (article-based)")
+except Exception as e:
+    print(f"⚠ Chart 3 (combined timeline) skipped — article_data.py not found: {e}")
+
+
+# ═══════════════ CHART 4 — Coverage Volume (round pie) ═══════════════
+fig, ax = plt.subplots(figsize=(8, 8))
+explode = (0.02,)*len(pie_sizes)
+wedges, texts, autotexts = ax.pie(pie_sizes, explode=explode, labels=pie_labels, colors=pie_colors,
+                                   autopct='%1.0f%%', startangle=140,
+                                   textprops={'fontsize': 9}, pctdistance=0.78)
+for t in autotexts:
+    t.set_fontsize(9); t.set_fontweight('bold'); t.set_color('white')
+ax.set_aspect('equal')
+ax.set_title('Estimated Coverage Volume by Source Type\n(See Appendix B for underlying data & article links)',
+             pad=15, fontsize=13)
+fig.tight_layout()
+fig.savefig(f'{OUT}/chart_coverage_volume.png', dpi=150, bbox_inches='tight')
+plt.close(); print("✓ Coverage volume")
+
+
+# ═══════════════ CHART 5 — Framing bar chart ═══════════════
+fig, ax = plt.subplots(figsize=(12, 6))
+x = np.arange(len(framing_categories))
+w = 0.2
+ax.bar(x-1.5*w, framing_accountability, w, label='LE Accountability', color='#e41a1c', alpha=0.85)
+ax.bar(x-0.5*w, framing_immigrant_sympathy, w, label='Sympathy for Subjects', color='#377eb8', alpha=0.85)
+ax.bar(x+0.5*w, framing_govt_credibility, w, label='Govt Credibility Concern', color='#4daf4a', alpha=0.85)
+ax.bar(x+1.5*w, framing_civil_liberties, w, label='Civil Liberties Emphasis', color='#ff7f00', alpha=0.85)
+ax.set_xticks(x); ax.set_xticklabels(framing_categories, fontweight='bold', fontsize=9)
+ax.set_ylabel('Emphasis Level (0–1)')
+ax.set_title('Narrative Framing Emphasis by Political Category', pad=15)
+ax.legend(loc='upper right', fontsize=8, framealpha=0.9)
+ax.set_ylim(0, 1.1)
+ax.spines['top'].set_visible(False); ax.spines['right'].set_visible(False)
+fig.tight_layout()
+fig.savefig(f'{OUT}/chart_framing.png', dpi=150, bbox_inches='tight')
+plt.close(); print("✓ Framing")
+
+print("\n✅ All charts generated.")

--- a/skills/media-coverage-analysis/scripts/generate_pdf_template.py
+++ b/skills/media-coverage-analysis/scripts/generate_pdf_template.py
@@ -82,8 +82,8 @@ NARRATIVE_SECTIONS = [
      "<b>Shift (Jan 24+):</b> Pretti killing fractured frame. WSJ/NY Post editorials broke. Fox reported perjury "
      "probe without defending officers. NR/DW still foregrounded immigration status."),
     ("The Left / Progressive",
-     "Sosa-Celis framed as victim of state violence from day one. Daily Beast: "How a Solitary Bullet Hole Blew "
-     "Apart ICE's Web of Lies." Salon ran three pieces. Common Dreams called for ICE abolition. "
+     "Sosa-Celis framed as victim of state violence from day one. Daily Beast: \"How a Solitary Bullet Hole Blew "
+     "Apart ICE's Web of Lies.\" Salon ran three pieces. Common Dreams called for ICE abolition. "
      "Register: <i>moral outrage and solidarity</i>. Third man's TX transfer framed as witness tampering."),
     ("The Center / Mainstream",
      "AP, CBS, NBC, ABC presented competing accounts. Shifted toward skepticism as evidence mounted. "
@@ -110,31 +110,31 @@ PUBLIC_SENTIMENT_DATA = [
 # source_aids_list should contain article IDs as they appear in article_data.py
 FACT_CHECKS = [
     ("'Sosa-Celis was armed'",
-     "DHS described men who "violently beat a law enforcement officer with weapons." Multiple right-leaning "
+     "DHS described men who \"violently beat a law enforcement officer with weapons.\" Multiple right-leaning "
      "outlets reported men wielded a snow shovel and broom handle as weapons.",
-     "No evidence indicates Sosa-Celis carried a firearm or weapon. The "weapons" were household items at "
+     "No evidence indicates Sosa-Celis carried a firearm or weapon. The \"weapons\" were household items at "
      "the residence. Photographic evidence showed the officer fired <i>through the front door</i> — "
      "inconsistent with a close-quarters street attack. Surveillance video did not corroborate the assault narrative.",
      "✘ FALSE — Sosa-Celis was unarmed. Household items retroactively characterized as weapons.",
      ['A34a', 'A15a', 'A22a', 'A31a', 'A27a']),
     ("'He attacked / ambushed ICE agents'",
-     "Sec. Noem: "an attempted murder of federal law enforcement." Federalist: "Propaganda Press Glosses Over "
-     "Attack On ICE Agent." Officers claimed they were beaten while on the ground.",
+     "Sec. Noem: \"an attempted murder of federal law enforcement.\" Federalist: \"Propaganda Press Glosses Over "
+     "Attack On ICE Agent.\" Officers claimed they were beaten while on the ground.",
      "Contradicted by: (1) city surveillance video; (2) two eyewitnesses within 10 feet; (3) neighbor testimony; "
      "(4) bullet hole through front door showing officer fired at retreating person. Prosecutors cited evidence "
-     ""materially inconsistent" with sworn testimony. All charges dismissed with prejudice. Two ICE officers "
+     "\"materially inconsistent\" with sworn testimony. All charges dismissed with prejudice. Two ICE officers "
      "now under federal perjury investigation.",
      "✘ FALSE — Assault narrative contradicted by video, physical evidence, and multiple witnesses.",
      ['A15b', 'A13a', 'A4b', 'A5a', 'A5b', 'A31a', 'A31b']),
     ("'He was a violent criminal'",
-     "DHS headline: "Three Violent Criminal Illegal Aliens." National Review: "brutal shovel beating." "
+     "DHS headline: \"Three Violent Criminal Illegal Aliens.\" National Review: \"brutal shovel beating.\" "
      "Adopted by Daily Wire, Federalist, OANN.",
      "Actual criminal record: <b>one conviction for driving without a license</b> and two arrests for giving "
      "a false name. Both minor, non-violent offenses. No violent criminal history in any court filing or investigation.",
      "✘ FALSE — Only conviction was a traffic offense.",
      ['A15a', 'A34a', 'A27a', 'A30a', 'A31a', 'A33a']),
     ("'He was an illegal alien subject to deportation'",
-     "DHS consistently used "illegal alien" and characterized the encounter as lawful enforcement.",
+     "DHS consistently used \"illegal alien\" and characterized the encounter as lawful enforcement.",
      "Entered US illegally Aug 2022 but subsequently <b>granted Temporary Protected Status (TPS)</b>, providing "
      "legal protection from deportation. Not under active deportation order at time of shooting. Working as "
      "DoorDash driver with a young son.",
@@ -150,8 +150,8 @@ FACT_CHECKS = [
     ("'The shooting was justified self-defense'",
      "Officer claimed he fired in self-defense while being ambushed, fearing for his life.",
      "FBI/DOJ investigation: (1) officer fired through closed door; (2) Sosa-Celis retreating into home when shot; "
-     "(3) video shows no active assault; (4) two officers provided "untruthful statements" under oath; "
-     "(5) evidence "materially inconsistent" with assault allegations. Non-fatal thigh wound. No body cameras deployed.",
+     "(3) video shows no active assault; (4) two officers provided \"untruthful statements\" under oath; "
+     "(5) evidence \"materially inconsistent\" with assault allegations. Non-fatal thigh wound. No body cameras deployed.",
      "⚠ EVIDENCE CONTRADICTS — Physical evidence, video, and witnesses inconsistent with self-defense. "
      "Perjury probe opened.",
      ['A9b', 'A10a', 'A8b', 'A20b']),
@@ -416,7 +416,7 @@ st.append(PageBreak())
 # ══════════ APPENDIX B — Government Narrative Alignment Basis ══════════
 st.append(Paragraph("Appendix B: Government Narrative Alignment — Basis Data", styles['H1']))
 st.append(Paragraph(
-    "This appendix provides the per-article data underlying the "Alignment with Government Narrative" "
+    "This appendix provides the per-article data underlying the \"Alignment with Government Narrative\" "
     "chart. Alignment is calculated as <b>(1 – sentiment) / 2</b>, mapping the -1 to +1 sentiment "
     "scale onto a 0–1 alignment scale where 1.0 = fully aligned with the DHS official account and "
     "0.0 = fully opposed. Each trace on the chart uses <b>only each outlet's most recent article</b> to "

--- a/skills/media-coverage-analysis/scripts/generate_pdf_template.py
+++ b/skills/media-coverage-analysis/scripts/generate_pdf_template.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""
+Generate PDF report — Template.
+Adapted from the working Sosa-Celis report to be generalized for any topic.
+
+This PDF includes:
+  - Title page with topic and date
+  - Timeline of key events
+  - Narrative framing analysis by political category
+  - Charts (sentiment scatter, combined timeline+alignment, coverage volume, framing)
+  - Public sentiment indicators
+  - Methodology
+  - Fact-check section with claim/evidence/verdict format
+  - Appendix A: Sentiment scoring rubric and article-level data
+  - Appendix B: Government narrative alignment data
+
+INSTRUCTIONS: Update the CONFIGURATION section below with your topic-specific data,
+then run this script. All PDF logic, styling, and structure remain unchanged.
+"""
+
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
+from reportlab.lib.units import inch
+from reportlab.lib.colors import HexColor
+from reportlab.lib.enums import TA_CENTER, TA_JUSTIFY
+from reportlab.platypus import (
+    SimpleDocTemplate, Paragraph, Spacer, Image, Table, TableStyle, PageBreak
+)
+from reportlab.lib import colors
+import os
+import sys
+
+# ════════════════════════════════════════════════════════════════════════════
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║                        CONFIGURATION SECTION                             ║
+# ║  Customize these values for your topic. Everything else is automatic.    ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+# ════════════════════════════════════════════════════════════════════════════
+
+# Path to directory containing your article_data.py file
+ARTICLE_DATA_DIR = "/sessions/bold-trusting-edison"
+
+# Output directory for the PDF and supporting charts
+OUT = "/sessions/bold-trusting-edison/mnt/2026-02-14 Missy Topics Research"
+
+# PDF filename and title
+TOPIC_TITLE = "The Story of Julio Cesar Sosa-Celis"
+REPORT_DATE = "February 14, 2026"
+TOPIC_WINDOW = "December 2025 – February 2026"
+PDF_FILENAME = "Sosa-Celis_Media_Coverage_Report.pdf"
+
+# Executive Summary — brief overview of the topic and its significance
+EXECUTIVE_SUMMARY = """
+The story of Julio Cesar Sosa-Celis — a 24-year-old Venezuelan man shot in the leg by an ICE agent
+in Minneapolis on January 14, 2026 — became a flashpoint in the national debate over immigration
+enforcement after video evidence contradicted sworn officer testimony, leading to dismissed charges
+and a federal perjury investigation. The case is embedded in the larger context of Operation Metro Surge,
+which also produced two fatal shootings of U.S. citizens (Renée Good and Alex Pretti), sparking
+nationwide protests and a rare fracture in conservative media's alignment with the government narrative.
+"""
+
+# Timeline events: (date_str, event_description)
+TIMELINE_EVENTS = [
+    ['Dec 1, 2025', 'Operation Metro Surge launched; thousands of agents deployed'],
+    ['Jan 7, 2026',  'Renée Good, 37, U.S. citizen, fatally shot by ICE agent'],
+    ['Jan 14, 2026', 'Sosa-Celis shot in the thigh during ICE traffic stop'],
+    ['Jan 15, 2026', 'DHS labels all three men "violent criminal illegal aliens"'],
+    ['Jan 16, 2026', 'Bystander videos emerge contradicting official account'],
+    ['Jan 24, 2026', 'Alex Pretti, 37, VA nurse, U.S. citizen, fatally shot'],
+    ['Jan 27, 2026', 'Conservative outlets (WSJ, NY Post, Free Press) break from govt narrative'],
+    ['Feb 5, 2026',  'Sosa-Celis\'s partner speaks publicly'],
+    ['Feb 13, 2026', 'ICE Director acknowledges "untruthful statements" under oath'],
+    ['Feb 14, 2026', 'All charges dismissed with prejudice; perjury probe opened'],
+]
+
+# Narrative framing sections: (title, body_text)
+NARRATIVE_SECTIONS = [
+    ("The Right / Conservative",
+     "<b>Initial (Jan 14–23):</b> Sosa-Celis presented as illegal alien who attacked officer. DHS language adopted "
+     "uncritically by Daily Wire, Federalist, National Review, OANN. Sentimental register: <i>indignation on behalf "
+     "of law enforcement</i>. <b>Far-right</b> (OANN, DW, Federalist) maintained this longer. "
+     "<b>Shift (Jan 24+):</b> Pretti killing fractured frame. WSJ/NY Post editorials broke. Fox reported perjury "
+     "probe without defending officers. NR/DW still foregrounded immigration status."),
+    ("The Left / Progressive",
+     "Sosa-Celis framed as victim of state violence from day one. Daily Beast: "How a Solitary Bullet Hole Blew "
+     "Apart ICE's Web of Lies." Salon ran three pieces. Common Dreams called for ICE abolition. "
+     "Register: <i>moral outrage and solidarity</i>. Third man's TX transfer framed as witness tampering."),
+    ("The Center / Mainstream",
+     "AP, CBS, NBC, ABC presented competing accounts. Shifted toward skepticism as evidence mounted. "
+     "Register: <i>institutional concern</i> — procedural, detached, focused on credibility of institutions."),
+    ("The Libertarian",
+     "Reason analyzed use-of-force policy. Cato: only 5% of detainees have violent convictions. "
+     "Register: <i>alarm about government overreach</i>. Gun-rights angle created common cause with progressives."),
+    ("The Localist / Minnesota",
+     "Sahan Journal centered community impact. MPR interviewed partner Indriany. "
+     "Register: <i>community under siege</i>. MN chief judge excoriating ICE for ignoring 90+ court orders."),
+]
+
+# Public sentiment indicators: (indicator, finding, source)
+PUBLIC_SENTIMENT_DATA = [
+    ['Video awareness', '82% of voters saw Good shooting video', 'Quinnipiac'],
+    ['Social media reach', '70% of Americans saw videos on social media', 'YouGov'],
+    ['ICE approval', 'Deeply divided; majority disapprove; Rs support expanded role', 'Multiple'],
+    ['Celebrity activism', 'Springsteen, Billie Eilish, Pedro Pascal, Jamie Lee Curtis', 'Multiple'],
+    ['Protest spread', 'Chicago, NYC, LA, SF, Seattle, DC + Minneapolis', 'NBC/CBS/AP'],
+    ['Sports crossover', 'NBA\'s Anthony Edwards criticized for weak response', 'Yahoo Sports'],
+]
+
+# Fact-check claims: (title, claim_text, evidence_text, verdict_text, source_aids_list)
+# source_aids_list should contain article IDs as they appear in article_data.py
+FACT_CHECKS = [
+    ("'Sosa-Celis was armed'",
+     "DHS described men who "violently beat a law enforcement officer with weapons." Multiple right-leaning "
+     "outlets reported men wielded a snow shovel and broom handle as weapons.",
+     "No evidence indicates Sosa-Celis carried a firearm or weapon. The "weapons" were household items at "
+     "the residence. Photographic evidence showed the officer fired <i>through the front door</i> — "
+     "inconsistent with a close-quarters street attack. Surveillance video did not corroborate the assault narrative.",
+     "✘ FALSE — Sosa-Celis was unarmed. Household items retroactively characterized as weapons.",
+     ['A34a', 'A15a', 'A22a', 'A31a', 'A27a']),
+    ("'He attacked / ambushed ICE agents'",
+     "Sec. Noem: "an attempted murder of federal law enforcement." Federalist: "Propaganda Press Glosses Over "
+     "Attack On ICE Agent." Officers claimed they were beaten while on the ground.",
+     "Contradicted by: (1) city surveillance video; (2) two eyewitnesses within 10 feet; (3) neighbor testimony; "
+     "(4) bullet hole through front door showing officer fired at retreating person. Prosecutors cited evidence "
+     ""materially inconsistent" with sworn testimony. All charges dismissed with prejudice. Two ICE officers "
+     "now under federal perjury investigation.",
+     "✘ FALSE — Assault narrative contradicted by video, physical evidence, and multiple witnesses.",
+     ['A15b', 'A13a', 'A4b', 'A5a', 'A5b', 'A31a', 'A31b']),
+    ("'He was a violent criminal'",
+     "DHS headline: "Three Violent Criminal Illegal Aliens." National Review: "brutal shovel beating." "
+     "Adopted by Daily Wire, Federalist, OANN.",
+     "Actual criminal record: <b>one conviction for driving without a license</b> and two arrests for giving "
+     "a false name. Both minor, non-violent offenses. No violent criminal history in any court filing or investigation.",
+     "✘ FALSE — Only conviction was a traffic offense.",
+     ['A15a', 'A34a', 'A27a', 'A30a', 'A31a', 'A33a']),
+    ("'He was an illegal alien subject to deportation'",
+     "DHS consistently used "illegal alien" and characterized the encounter as lawful enforcement.",
+     "Entered US illegally Aug 2022 but subsequently <b>granted Temporary Protected Status (TPS)</b>, providing "
+     "legal protection from deportation. Not under active deportation order at time of shooting. Working as "
+     "DoorDash driver with a young son.",
+     "⚠ MISLEADING — Original entry unlawful but held legal TPS status at time of encounter.",
+     ['A22a', 'A34a', 'A18a']),
+    ("'Venezuelan gang member / Tren de Aragua'",
+     "Operation framed as targeting TdA gang members. Some outlets grouped Sosa-Celis with gang-connected individuals.",
+     "No evidence in any filing links Sosa-Celis to TdA or any gang. Working as delivery driver, no violent history, "
+     "had family. FBI revealed operation was based on <b>mistaken identity</b> — agents sought a different "
+     "individual (Joffre Stalin Paucar Barrera).",
+     "✘ UNSUBSTANTIATED — No evidence of gang affiliation. Bystander in mistaken-identity operation.",
+     ['A22a', 'A8b', 'A34a']),
+    ("'The shooting was justified self-defense'",
+     "Officer claimed he fired in self-defense while being ambushed, fearing for his life.",
+     "FBI/DOJ investigation: (1) officer fired through closed door; (2) Sosa-Celis retreating into home when shot; "
+     "(3) video shows no active assault; (4) two officers provided "untruthful statements" under oath; "
+     "(5) evidence "materially inconsistent" with assault allegations. Non-fatal thigh wound. No body cameras deployed.",
+     "⚠ EVIDENCE CONTRADICTS — Physical evidence, video, and witnesses inconsistent with self-defense. "
+     "Perjury probe opened.",
+     ['A9b', 'A10a', 'A8b', 'A20b']),
+]
+
+# Fact-check summary table: (number, claim, verdict, key_evidence)
+FACT_CHECK_SUMMARY = [
+    ['1', 'Sosa-Celis was armed', '✘ False', 'No weapon found; bullet hole through door'],
+    ['2', 'He attacked/ambushed agents', '✘ False', 'Video, witnesses, physical evidence contradict'],
+    ['3', 'He was a violent criminal', '✘ False', 'Only conviction: driving without license'],
+    ['4', 'He was an illegal alien', '⚠ Misleading', 'Held Temporary Protected Status'],
+    ['5', 'Gang member / TdA', '✘ Unsubstantiated', 'No evidence; mistaken identity operation'],
+    ['6', 'Shooting justified', '⚠ Contradicted', 'Fired through door; perjury probe opened'],
+]
+
+# Sentiment scoring rubric explanations
+RUBRIC_CRITERIA = [
+    ['Subject description', '"illegal alien," "criminal" in headline',
+     'Name + nationality neutrally', 'Name only, "resident," humanizing detail'],
+    ['Account primacy', 'Govt account leads, defense buried', 'Both accounts equal',
+     'Defense/victim leads, govt challenged'],
+    ['Emotional register', 'Indignation toward subject', 'Procedural, detached',
+     'Outrage on behalf of subject'],
+    ['Immigration status', 'Foregrounded in headline as framing', 'Mentioned in body only',
+     'Omitted or de-emphasized'],
+]
+
+# Alignment formula interpretation table
+ALIGNMENT_FORMULA = [
+    ['+1.00 (max sympathetic)', '0.00', 'Fully opposed to govt narrative'],
+    ['+0.50', '0.25', 'Mostly opposed'],
+    ['0.00 (neutral)', '0.50', 'Neutral / balanced'],
+    ['-0.50', '0.75', 'Mostly aligned'],
+    ['-1.00 (max hostile)', '1.00', 'Fully aligned with govt narrative'],
+]
+
+# ════════════════════════════════════════════════════════════════════════════
+# END CONFIGURATION — Below this line, no customization needed
+# ════════════════════════════════════════════════════════════════════════════
+
+# Import article data
+sys.path.insert(0, ARTICLE_DATA_DIR)
+try:
+    from article_data import ARTICLES, OUTLET_X, OUTLET_CAT
+except ImportError as e:
+    print(f"ERROR: Could not import article_data from {ARTICLE_DATA_DIR}")
+    print(f"Make sure article_data.py exists in that directory.")
+    sys.exit(1)
+
+PDF_PATH = f"{OUT}/{PDF_FILENAME}"
+
+doc = SimpleDocTemplate(PDF_PATH, pagesize=letter,
+    topMargin=0.6*inch, bottomMargin=0.6*inch, leftMargin=0.7*inch, rightMargin=0.7*inch)
+
+styles = getSampleStyleSheet()
+S = styles.add
+S(ParagraphStyle('RT', parent=styles['Title'], fontSize=22, spaceAfter=6,
+    textColor=HexColor('#1a1a2e'), fontName='Helvetica-Bold'))
+S(ParagraphStyle('RS', parent=styles['Normal'], fontSize=12, spaceAfter=20,
+    textColor=HexColor('#666'), alignment=TA_CENTER, fontName='Helvetica'))
+S(ParagraphStyle('H1', parent=styles['Heading1'], fontSize=16, spaceBefore=18, spaceAfter=10,
+    textColor=HexColor('#1a1a2e'), fontName='Helvetica-Bold', borderWidth=0))
+S(ParagraphStyle('H2', parent=styles['Heading2'], fontSize=13, spaceBefore=14, spaceAfter=6,
+    textColor=HexColor('#333366'), fontName='Helvetica-Bold'))
+S(ParagraphStyle('H3', parent=styles['Heading3'], fontSize=11, spaceBefore=10, spaceAfter=4,
+    textColor=HexColor('#444488'), fontName='Helvetica-Bold'))
+S(ParagraphStyle('B', parent=styles['Normal'], fontSize=10, leading=14, spaceAfter=8,
+    alignment=TA_JUSTIFY, fontName='Helvetica'))
+S(ParagraphStyle('SN', parent=styles['Normal'], fontSize=8, leading=10,
+    textColor=HexColor('#888'), fontName='Helvetica-Oblique'))
+S(ParagraphStyle('TC', parent=styles['Normal'], fontSize=8.5, leading=11, fontName='Helvetica'))
+S(ParagraphStyle('TH', parent=styles['Normal'], fontSize=9, leading=11,
+    fontName='Helvetica-Bold', textColor=colors.white))
+S(ParagraphStyle('AE', parent=styles['Normal'], fontSize=9, leading=12, spaceAfter=3, fontName='Helvetica'))
+
+TS = TableStyle([
+    ('BACKGROUND', (0,0), (-1,0), HexColor('#1a1a2e')),
+    ('TEXTCOLOR', (0,0), (-1,0), colors.white),
+    ('VALIGN', (0,0), (-1,-1), 'TOP'),
+    ('GRID', (0,0), (-1,-1), 0.5, HexColor('#ccc')),
+    ('ROWBACKGROUNDS', (0,1), (-1,-1), [colors.white, HexColor('#f5f5ff')]),
+    ('TOPPADDING', (0,0), (-1,-1), 3), ('BOTTOMPADDING', (0,0), (-1,-1), 3),
+])
+
+def tbl(hdrs, rows, cw):
+    """Build a styled table."""
+    d = [[Paragraph(h, styles['TH']) for h in hdrs]]
+    for r in rows: d.append([Paragraph(str(c), styles['TC']) for c in r])
+    t = Table(d, colWidths=cw); t.setStyle(TS); return t
+
+def img(n, w, h):
+    """Load image if it exists, else return spacer."""
+    p = f"{OUT}/{n}"
+    return Image(p, width=w, height=h) if os.path.exists(p) else Spacer(1, 12)
+
+st = []
+
+# ── Title Page ──
+st.append(Spacer(1, 1.2*inch))
+st.append(Paragraph("Media Coverage &amp; Sentiment Analysis", styles['RT']))
+st.append(Paragraph(TOPIC_TITLE, styles['RT']))
+st.append(Spacer(1, 10))
+st.append(Paragraph(f"Report Date: {REPORT_DATE} | Topic Window: {TOPIC_WINDOW}", styles['RS']))
+st.append(Spacer(1, 20))
+st.append(Paragraph("Executive Summary", styles['H1']))
+st.append(Paragraph(EXECUTIVE_SUMMARY, styles['B']))
+st.append(PageBreak())
+
+# ── Timeline ──
+st.append(Paragraph("Timeline of Key Events", styles['H1']))
+st.append(img('chart_timeline.png', 6.8*inch, 3.8*inch))
+st.append(Spacer(1, 4))
+st.append(tbl(['Date', 'Event'], TIMELINE_EVENTS, [1*inch, 5.6*inch]))
+st.append(PageBreak())
+
+# ── Sentiment & Narrative ──
+st.append(Paragraph("Sentiment &amp; Narrative Framing", styles['H1']))
+for title, body in NARRATIVE_SECTIONS:
+    st.append(Paragraph(title, styles['H2']))
+    st.append(Paragraph(body, styles['B']))
+st.append(PageBreak())
+
+# ── Sentiment Map & Shift Over Time ──
+st.append(Paragraph("Sentiment Map &amp; Shift Over Time", styles['H1']))
+st.append(img('chart_sentiment_shift.png', 6.5*inch, 4.0*inch))
+st.append(Paragraph(
+    "Each point = one article (52 total). <b>Size and opacity encode recency</b> — smaller/faded = earlier, "
+    "larger/bold = more recent. Arrows trace chronological shift within each outlet. "
+    "<b>Marker shapes:</b> ■ squares = Left/Far Left, ◆ diamonds = Center-Left &amp; Center-Right, "
+    "● circles = Center, ▲ triangles = Right/Far Right, ✙ plus = Libertarian, ✕ X = Government. "
+    "All 52 articles with dates, scores, and links in <b>Appendix A</b>.", styles['B']))
+st.append(Paragraph(
+    "Key findings: strong diagonal (left = sympathetic, right = hostile), but arrows show every multi-article outlet "
+    "shifted upward over time. Fox News moved -0.50 → -0.05. Daily Beast +0.75 → +0.95. "
+    "Far-right outlets shifted up but stayed hostile. Left barely moved (skeptical from day one). "
+    "DHS (single point, bottom-right) never shifted.", styles['B']))
+st.append(PageBreak())
+
+# ── Combined Timeline + Govt Narrative Alignment ──
+st.append(Paragraph("Timeline &amp; Alignment with Government Narrative", styles['H1']))
+st.append(img('chart_combined_timeline_shift.png', 6.8*inch, 4.2*inch))
+st.append(Paragraph(
+    "Bottom panel: each point marks an article publication date. At each point, the y-value is the average "
+    "alignment across all outlets in that category, using <b>only each outlet's most recent article</b> "
+    "(computed as (1 – sentiment) / 2, where hostile-to-subject = high alignment). "
+    "When an outlet publishes a new article, it replaces the old one in the group average. "
+    "Right dropped from ~0.81 to ~0.55 as Fox News and Washington Times softened. "
+    "Far-Right fell from ~0.95 to ~0.77 but remained above all other categories. "
+    "See <b>Appendix B</b> for the per-article alignment scores underlying these traces.", styles['B']))
+
+# ── Coverage Volume ──
+st.append(Paragraph("Coverage Volume by Source Type", styles['H1']))
+st.append(img('chart_coverage_volume.png', 4.5*inch, 4.5*inch))
+st.append(Paragraph("See <b>Appendix B</b> for underlying data and article links.", styles['B']))
+st.append(PageBreak())
+
+# ── Framing ──
+st.append(Paragraph("Narrative Framing by Political Category", styles['H1']))
+st.append(img('chart_framing.png', 6.5*inch, 3.5*inch))
+st.append(Paragraph(
+    "Now includes <b>Far Right</b> as separate category. Far-right scored near zero on sympathy and civil "
+    "liberties but maintained some govt-credibility concern after the perjury probe.", styles['B']))
+
+# ── Public Sentiment ──
+st.append(Paragraph("Public Sentiment Indicators", styles['H1']))
+st.append(tbl(['Indicator', 'Finding', 'Source'], PUBLIC_SENTIMENT_DATA, [1.2*inch, 3.5*inch, 1.6*inch]))
+st.append(PageBreak())
+
+# ── Methodology ──
+st.append(Paragraph("Methodology", styles['H1']))
+st.append(Paragraph(
+    "Compiled Feb 14, 2026 via web search across 28 outlets. Political-leaning baselines from AllSides and "
+    "Ad Fontes Media, adjusted ±0.3 for story-specific framing. Sentiment follows explicit rubric in Appendix A. "
+    "Coverage volume approximate. All scores are documented qualitative judgment, not algorithmic.", styles['SN']))
+st.append(PageBreak())
+
+# ── Fact-Check Section ──
+st.append(Paragraph("Fact-Check: Key Claims in Media Coverage", styles['H1']))
+st.append(Paragraph(
+    "A significant feature of this story is the gap between assertions made in early coverage (often parroting "
+    "DHS press releases) and what subsequent evidence revealed. Below, key claims are evaluated against the "
+    "evidentiary record.", styles['B']))
+
+# Build URL lookup from article data
+article_url = {}
+for _o, _aid, _d, _y, _hl, _url, _s in ARTICLES:
+    article_url[_aid] = _url
+
+def aid_link(aid):
+    """Return a clickable article ID link."""
+    url = article_url.get(aid, '')
+    if url:
+        return f'<a href="{url}" color="#1a0dab">{aid}</a>'
+    return aid
+
+def aid_links(aids):
+    """Return comma-separated clickable article ID links."""
+    return ', '.join(aid_link(a) for a in aids)
+
+# Render fact-checks
+for title, claim_text, evidence_text, verdict_text, source_aids in FACT_CHECKS:
+    st.append(Paragraph(f"Claim: {title}", styles['H2']))
+    st.append(Paragraph(f"<b>As stated:</b> {claim_text}", styles['B']))
+    st.append(Paragraph(f"<b>Evidence:</b> {evidence_text}", styles['B']))
+    st.append(Paragraph(f"<b>Verdict:</b> {verdict_text}", styles['B']))
+    st.append(Paragraph(f"<i>Sources: {aid_links(source_aids)}</i>", styles['SN']))
+    st.append(Spacer(1, 6))
+
+# Summary table
+st.append(Paragraph("Fact-Check Summary", styles['H2']))
+st.append(tbl(
+    ['#', 'Claim', 'Verdict', 'Key Evidence'],
+    FACT_CHECK_SUMMARY,
+    [0.3*inch, 1.6*inch, 1.1*inch, 3.3*inch]
+))
+st.append(PageBreak())
+
+# ══════════ APPENDIX A — Article-Level ══════════
+st.append(Paragraph("Appendix A: Sentiment Scoring Rubric &amp; Source Articles", styles['H1']))
+st.append(Paragraph("Scoring Rubric", styles['H2']))
+st.append(Paragraph(
+    "<b>Political Orientation (x-axis, -3 to +3):</b> AllSides/Ad Fontes baseline ±0.3 for story framing.", styles['B']))
+st.append(Paragraph(
+    "<b>Sentiment (y-axis, -1 to +1):</b> Sum of four criteria scored -0.25 to +0.25 each:", styles['B']))
+st.append(tbl(
+    ['Criterion', '-0.25 (hostile)', '0 (neutral)', '+0.25 (sympathetic)'],
+    RUBRIC_CRITERIA,
+    [1.1*inch, 1.6*inch, 1.5*inch, 1.9*inch]
+))
+st.append(Spacer(1, 8))
+
+# Article-level table from dataset
+sorted_articles = sorted(ARTICLES, key=lambda a: (OUTLET_X[a[0]], a[2]))
+
+st.append(Paragraph("Article-Level Scoring (52 Articles)", styles['H2']))
+st.append(Paragraph(
+    "Each row = one data point on the sentiment map. Sorted by political orientation (left to right), then date.", styles['B']))
+
+# Split into chunks of ~13 articles per page
+chunk_size = 13
+for i in range(0, len(sorted_articles), chunk_size):
+    chunk = sorted_articles[i:i+chunk_size]
+    rows = []
+    for outlet, aid, date, y, headline, url, scores in chunk:
+        x = OUTLET_X[outlet]
+        date_str = date.strftime("%b %d")
+        hl = headline if len(headline) <= 50 else headline[:47] + "..."
+        if url:
+            hl_linked = f'<a href="{url}" color="#1a0dab">{hl}</a>'
+        else:
+            hl_linked = hl
+        rows.append([aid, date_str, outlet, f"{x:+.1f}", f"{y:+.2f}", scores, hl_linked])
+    st.append(tbl(
+        ['ID', 'Date', 'Outlet', 'x', 'y', 'Scores', 'Headline'],
+        rows,
+        [0.4*inch, 0.5*inch, 1.0*inch, 0.35*inch, 0.4*inch, 1.3*inch, 2.4*inch]
+    ))
+    st.append(Spacer(1, 4))
+
+st.append(PageBreak())
+
+# ══════════ APPENDIX B — Government Narrative Alignment Basis ══════════
+st.append(Paragraph("Appendix B: Government Narrative Alignment — Basis Data", styles['H1']))
+st.append(Paragraph(
+    "This appendix provides the per-article data underlying the "Alignment with Government Narrative" "
+    "chart. Alignment is calculated as <b>(1 – sentiment) / 2</b>, mapping the -1 to +1 sentiment "
+    "scale onto a 0–1 alignment scale where 1.0 = fully aligned with the DHS official account and "
+    "0.0 = fully opposed. Each trace on the chart uses <b>only each outlet's most recent article</b> to "
+    "compute the group average — when an outlet publishes a new article, it replaces the old one. "
+    "A new point is plotted each time any article in the category is published.", styles['B']))
+
+st.append(Paragraph("Formula &amp; Interpretation", styles['H2']))
+st.append(tbl(
+    ['Sentiment (y)', 'Alignment', 'Interpretation'],
+    ALIGNMENT_FORMULA,
+    [1.8*inch, 0.8*inch, 3.0*inch]
+))
+st.append(Spacer(1, 8))
+
+# Build alignment data
+def govt_align_pdf(y_sent):
+    return max(0, min(1, (1 - y_sent) / 2))
+
+def broad_cat_pdf(outlet):
+    x = OUTLET_X[outlet]
+    cat = OUTLET_CAT[outlet]
+    if cat == 'gov': return 'Gov'
+    if cat == 'libertarian': return 'Libertarian'
+    if cat == 'left': return 'Left'
+    if cat in ('center-left',): return 'Center-Left'
+    if cat in ('center', 'center-right'): return 'Center'
+    if cat == 'right' and x >= 2.3: return 'Far-Right'
+    if cat == 'right': return 'Right'
+    return 'Center'
+
+from datetime import datetime
+EVENT_START = datetime(2026, 1, 14)
+
+align_rows = []
+for outlet, aid, date, y, headline, url, scores in ARTICLES:
+    if date < EVENT_START: continue
+    bc = broad_cat_pdf(outlet)
+    if bc == 'Gov': continue
+    align_rows.append((date, aid, outlet, bc, y, govt_align_pdf(y), headline))
+align_rows.sort(key=lambda r: (r[0], r[3]))
+
+st.append(Paragraph("Per-Article Alignment Scores (Sorted by Date)", styles['H2']))
+
+chunk_size = 18
+for i in range(0, len(align_rows), chunk_size):
+    chunk = align_rows[i:i+chunk_size]
+    rows = []
+    for date, aid, outlet, bc, y, alignment, headline in chunk:
+        url = article_url.get(aid, '')
+        aid_cell = f'<a href="{url}" color="#1a0dab">{aid}</a>' if url else aid
+        rows.append([
+            aid_cell,
+            date.strftime("%b %d"),
+            outlet,
+            bc,
+            f"{y:+.2f}",
+            f"{alignment:.2f}",
+        ])
+    st.append(tbl(
+        ['ID', 'Date', 'Outlet', 'Category', 'Sent.', 'Align.'],
+        rows,
+        [0.4*inch, 0.5*inch, 1.1*inch, 1.0*inch, 0.5*inch, 0.5*inch]
+    ))
+    st.append(Spacer(1, 4))
+
+st.append(Spacer(1, 15))
+st.append(Paragraph("Report generated for research purposes. All links accessible as of Feb 14, 2026.", styles['SN']))
+
+doc.build(st)
+print(f"✅ PDF saved: {PDF_PATH}")

--- a/skills/media-coverage-analysis/scripts/generate_shift_chart_template.py
+++ b/skills/media-coverage-analysis/scripts/generate_shift_chart_template.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""
+Generate article-level sentiment shift chart — Template.
+Adapted from the working Sosa-Celis report to be generalized for any topic.
+
+Each article is plotted as a data point. Recent articles are larger and more opaque.
+Arrows connect articles from the same outlet chronologically.
+
+INSTRUCTIONS: Update the CONFIGURATION section to point to your article_data.py file
+and output directory, then run this script. All visualization logic remains unchanged.
+"""
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from matplotlib.lines import Line2D
+import matplotlib.dates as mdates
+from collections import defaultdict
+import numpy as np
+import os, sys
+
+# ════════════════════════════════════════════════════════════════════════════
+# ╔═══════════════════════════════════════════════════════════════════════════╗
+# ║                        CONFIGURATION SECTION                             ║
+# ║  Customize only these two paths. Everything else is automatic.           ║
+# ╚═══════════════════════════════════════════════════════════════════════════╝
+# ════════════════════════════════════════════════════════════════════════════
+
+# Path to directory containing your article_data.py file
+ARTICLE_DATA_DIR = "/sessions/bold-trusting-edison"
+
+# Output directory for the chart
+OUT = "/sessions/bold-trusting-edison/mnt/2026-02-14 Missy Topics Research"
+
+# ════════════════════════════════════════════════════════════════════════════
+# END CONFIGURATION — Below this line, no customization needed
+# ════════════════════════════════════════════════════════════════════════════
+
+# Import article data from specified directory
+sys.path.insert(0, ARTICLE_DATA_DIR)
+try:
+    from article_data import ARTICLES, OUTLET_X, OUTLET_CAT
+except ImportError as e:
+    print(f"ERROR: Could not import article_data from {ARTICLE_DATA_DIR}")
+    print(f"Make sure article_data.py exists in that directory.")
+    sys.exit(1)
+
+os.makedirs(OUT, exist_ok=True)
+
+# Color scheme
+LEFT_C = '#2171b5'
+CENTER_C = '#6a51a3'
+RIGHT_C = '#cb181d'
+LIBERT_C = '#f59e0b'
+GOV_C = '#525252'
+
+cat_style = {
+    'left':         (LEFT_C,    's'),
+    'center-left':  ('#4292c6', 'D'),
+    'center':       (CENTER_C,  'o'),
+    'center-right': ('#fb6a4a', 'D'),
+    'right':        (RIGHT_C,   '^'),
+    'libertarian':  (LIBERT_C,  'P'),
+    'gov':          (GOV_C,     'X'),
+}
+
+plt.rcParams.update({
+    'figure.facecolor': '#fafafa', 'axes.facecolor': '#fafafa',
+    'font.family': 'sans-serif', 'font.size': 10,
+    'axes.titlesize': 13, 'axes.titleweight': 'bold',
+})
+
+# ── Compute date range for alpha and size mapping ──
+from datetime import datetime
+all_dates = [a[2] for a in ARTICLES]
+date_min = min(all_dates)
+date_max = max(all_dates)
+date_range = (date_max - date_min).days or 1
+
+def date_to_alpha(d):
+    """More recent articles get higher alpha. Range: 0.2 (oldest) to 1.0 (newest)."""
+    frac = (d - date_min).days / date_range
+    return 0.20 + 0.80 * frac
+
+def date_to_size(d):
+    """More recent articles are larger. Range: 50 (oldest) to 180 (newest)."""
+    frac = (d - date_min).days / date_range
+    return 50 + 130 * frac
+
+# ── Group articles by outlet (for drawing arrows) ──
+by_outlet = defaultdict(list)
+for outlet, aid, date, y, headline, url, scores in ARTICLES:
+    x = OUTLET_X[outlet]
+    cat = OUTLET_CAT[outlet]
+    by_outlet[outlet].append((date, x, y, aid, cat, headline))
+
+# Sort each outlet's articles by date
+for k in by_outlet:
+    by_outlet[k].sort(key=lambda t: t[0])
+
+
+# ═══════════════ CHART — Article-Level Sentiment Shift ═══════════════
+fig, ax = plt.subplots(figsize=(16, 10))
+ax.set_title(
+    'Sentiment Trajectory by Article\n'
+    '(Each point = one article; opacity & size = recency; arrows = chronological shift within outlet)',
+    fontsize=13, fontweight='bold', pad=18)
+
+# Draw arrows first (behind points)
+for outlet, points in by_outlet.items():
+    if len(points) < 2:
+        continue
+    cat = points[0][4]
+    c, _ = cat_style[cat]
+    for i in range(len(points) - 1):
+        d1, x1, y1 = points[i][0], points[i][1], points[i][2]
+        d2, x2, y2 = points[i+1][0], points[i+1][1], points[i+1][2]
+        # Arrow from earlier to later
+        dy = y2 - y1
+        if abs(dy) > 0.02:
+            alpha_arr = min(date_to_alpha(d1), date_to_alpha(d2)) * 0.5
+            ax.annotate('', xy=(x2, y2), xytext=(x1, y1),
+                        arrowprops=dict(arrowstyle='->', color=c,
+                                        lw=1.5, alpha=alpha_arr,
+                                        connectionstyle='arc3,rad=0.0'))
+
+# Plot each article as a point
+for outlet, aid, date, y, headline, url, scores in ARTICLES:
+    x = OUTLET_X[outlet]
+    cat = OUTLET_CAT[outlet]
+    c, m = cat_style[cat]
+    alpha = date_to_alpha(date)
+    size = date_to_size(date)
+    ax.scatter(x, y, c=c, marker=m, s=size, zorder=5, alpha=alpha,
+               edgecolors='white', linewidth=0.5)
+
+# Label the LATEST article for each outlet (most prominent)
+for outlet, points in by_outlet.items():
+    latest = points[-1]  # already sorted by date
+    d, x, y, aid, cat, headline = latest
+    c, _ = cat_style[cat]
+    label = f"{outlet} [{aid}]"
+    ax.annotate(label, (x, y), textcoords="offset points", xytext=(9, -3),
+                fontsize=6, color=c, fontweight='bold', alpha=0.9)
+
+    # If outlet has multiple articles, also faintly label earliest
+    if len(points) > 1:
+        earliest = points[0]
+        d0, x0, y0, aid0, cat0, hl0 = earliest
+        ax.annotate(f"[{aid0}]", (x0, y0), textcoords="offset points", xytext=(7, 3),
+                    fontsize=5, color=c, alpha=0.45)
+
+ax.axhline(0, color='#cccccc', linewidth=0.8, linestyle='--')
+ax.axvline(0, color='#cccccc', linewidth=0.8, linestyle='--')
+ax.set_xlim(-3.5, 3.5)
+ax.set_ylim(-1.15, 1.15)
+ax.set_xlabel('← Left-Leaning                    Political Orientation                    Right-Leaning →', fontsize=11)
+ax.set_ylabel('← Hostile to Subject         Sentiment Toward Sosa-Celis         Sympathetic →', fontsize=11)
+
+# Quadrant labels
+ax.text(-3.0, 1.02, 'Left + Sympathetic', fontsize=8, color='#999', style='italic')
+ax.text(1.8, 1.02, 'Right + Sympathetic', fontsize=8, color='#999', style='italic')
+ax.text(-3.0, -1.08, 'Left + Hostile', fontsize=8, color='#999', style='italic')
+ax.text(2.0, -1.08, 'Right + Hostile', fontsize=8, color='#999', style='italic')
+
+# Explanation
+ax.text(0.5, -0.03,
+        f'Each point = 1 article ({len(ARTICLES)} total)  ·  Smaller/faded = earlier  ·  Larger/opaque = more recent  ·  '
+        'Arrows = shift within outlet  ·  See Appendix A for full article list',
+        transform=ax.transAxes, fontsize=7.5, color='#666', ha='center', style='italic')
+
+# Legend
+legend_handles = [
+    Line2D([0], [0], marker='o', color='w', markerfacecolor='grey',
+           markeredgecolor='white', markersize=5, alpha=0.25, label='Earlier article (faded, small)'),
+    Line2D([0], [0], marker='o', color='w', markerfacecolor='grey',
+           markeredgecolor='white', markersize=10, alpha=1.0, label='Latest article (bold, large)'),
+    Line2D([0], [0], color='grey', linewidth=1.5, alpha=0.4, label='Chronological shift arrow'),
+]
+for cat_key, lbl in [('left', 'Left/Far Left'), ('center-left', 'Ctr-Left'),
+                      ('center', 'Center'), ('center-right', 'Ctr-Right'),
+                      ('right', 'Right/Far Right'), ('libertarian', 'Libertarian'), ('gov', 'Govt')]:
+    c2, m2 = cat_style[cat_key]
+    legend_handles.append(Line2D([0], [0], marker=m2, color='w', markerfacecolor=c2,
+                                 markeredgecolor='white', markersize=8, label=lbl))
+
+ax.legend(handles=legend_handles, loc='upper left', fontsize=7, framealpha=0.92,
+          title='Legend', title_fontsize=8, borderpad=0.8, labelspacing=0.45, ncol=2)
+
+ax.spines['top'].set_visible(False)
+ax.spines['right'].set_visible(False)
+fig.tight_layout()
+fig.savefig(f'{OUT}/chart_sentiment_shift.png', dpi=150, bbox_inches='tight')
+plt.close()
+print(f"✓ Article-level sentiment shift chart ({len(ARTICLES)} articles)")
+print(f"\n✅ Done. Chart saved to: {OUT}/chart_sentiment_shift.png")


### PR DESCRIPTION
## Summary
- Migrate `media-coverage-analysis` skill from `~/.claude/skills/` into `skills/media-coverage-analysis/`, excluding the 926 MB `.venv/` and `.DS_Store`
- Add repo-standard frontmatter (`license`, `metadata.author`, `metadata.version`); fold the long description with `>-` (was `>`) so the tail "news analysis." doesn't trail a blank line
- Add a `## Setup` section to `SKILL.md` documenting the `uv venv` + `uv pip install -r requirements.txt` bootstrap and `.venv/bin/python scripts/...` invocation
- Commit `requirements.txt` with only the deps the template scripts actually import (`matplotlib`, `numpy`, `reportlab`); NLP deps from the "TODO: Future Exploration" section are left out intentionally — install on demand
- Add `.venv/` to repo `.gitignore`

## Closes
Closes #17

## Plan compliance
- [x] Step 1 (create `skills/media-coverage-analysis/`) — DONE
- [x] Step 2 (rsync source, exclude `.venv/` and `.DS_Store`) — DONE
- [x] Step 3 (update frontmatter to repo standard) — DONE (no `disable-model-invocation` in source; nothing to preserve there)
- [x] Step 4 (add Setup section + requirements.txt + venv-relative invocation examples) — DONE; derived deps from script imports since no `pyproject.toml`/`requirements.txt` existed in source
- [x] Step 5 (add `.venv/` to repo `.gitignore`) — DONE; `.DS_Store` was already covered by the existing unscoped rule
- [ ] Step 6 (open PR, resolve comments, merge) — in progress
- [ ] Step 7 (post-merge `install.sh --global`, delete source, bootstrap venv in repo) — deferred to post-merge
- [ ] Step 8 (smoke test in fresh session) — deferred to post-merge

## Test plan
- [x] `./install.sh --list` shows `media-coverage-analysis` with a non-empty description
- [x] Frontmatter valid (`name: media-coverage-analysis` matches dir; `license: MIT`; `metadata.author`/`version` set)
- [x] `scripts/`, `references/`, `assets/` preserved (4 reference files, 3 template scripts + TEMPLATE_USAGE.md)
- [ ] Post-merge: `./install.sh --global media-coverage-analysis` runs clean, source removed, venv bootstraps, skill invocable

🤖 Generated with [Claude Code](https://claude.com/claude-code)