### PR TITLE
Migrate submit-monthly-expenses skill

### DIFF
--- a/skills/submit-monthly-expenses/SKILL.md
+++ b/skills/submit-monthly-expenses/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: submit-monthly-expenses
+description: >-
+  Monthly expense management workflow for AMPS Unlimited 1.0 LLC. Handles
+  downloading receipts from vendor portals (Google Workspace, AWS, WyomingAgents,
+  Zenbusiness Banking, GitHub, Anthropic), renaming files to standard format,
+  organizing in the expense receipts folder, uploading to Zoho Expense, and
+  generating monthly expense reports. Use when processing monthly business
+  expenses, reconciling receipts, or preparing expense reports.
+license: MIT
+metadata:
+  author: natecostello
+  version: "0.1"
+---
+
+# Monthly Expenses Workflow
+
+Process monthly LLC expenses step-by-step: download → rename → organize → upload → report.
+
+## Receipt Folder
+
+**Location:** `/Users/ncos/Documents/File_cabinet/AMPS Unlimited/Expense Reciepts`
+
+## File Naming Convention
+
+Format: `YYYY-MM-DD-Vendor.pdf`
+
+Examples:
+- `2026-01-01-Google Workspace.pdf`
+- `2026-01-01-AWS.pdf`
+- `2026-01-07-WyomingAgents - Virtual Office.pdf`
+- `2026-01-15-GitHub.pdf`
+- `2026-01-18-zb-banking-3686821.pdf` (preserves invoice number)
+- `2026-01-26-Anthropic-Receipt-2823-4502-6365.pdf` (preserves receipt number)
+
+## Monthly Workflow
+
+### Step 0: Setup
+
+1. **Create monthly folder:** Create `Downloads/YYYY-Mon-Expenses/` (e.g., `2026-Feb-Expenses`)
+
+2. **Open browser tabs** to all login pages:
+   - AWS: https://console.aws.amazon.com/billing
+   - GitHub: https://github.com/settings/billing
+   - Anthropic: https://claude.ai/settings/billing
+   - WyomingAgents: https://accounts.wyomingagents.com
+   - Zenbusiness: https://www.zenbusiness.com/my-business
+   - Google Workspace: https://admin.google.com/ac/billing (requires AMPS Unlimited Chrome profile)
+   - Zoho Expense: https://expense.zoho.com
+   - YNAB: https://app.ynab.com
+
+3. **Prompt user:** "Please log into all vendor sites, Zoho Expense, and YNAB. Also add any ad-hoc/manual receipts to `Downloads/YYYY-Mon-Expenses/`. Let me know when ready."
+
+4. **Wait for user confirmation** before proceeding to Step 1.
+
+### Step 1: Download Receipts
+
+Once user confirms login, assist with navigating to and downloading receipts from each portal.
+
+**Regular monthly vendors (see references/vendors.md for details):**
+
+| Vendor | Billing Date | Portal |
+|--------|--------------|--------|
+| Google Workspace | ~1st | admin.google.com → Billing (AMPS Unlimited Chrome profile) |
+| AWS | ~1st | console.aws.amazon.com → Billing |
+| WyomingAgents Virtual Office | ~7th | accounts.wyomingagents.com → Account |
+| GitHub | ~15th | github.com/settings/billing |
+| Zenbusiness Banking | ~18th | zenbusiness.com → My Business → Order History |
+| Anthropic | ~26th | claude.ai/settings/billing |
+
+**Periodic vendors:** Biberk insurance, Squarespace domains, Zoho, Toggl, ChatGPT
+
+For each download, confirm with user before saving.
+
+### Step 2: Rename and Organize Files
+
+After each download, rename and move to the monthly working folder:
+
+1. Identify downloaded file (usually in Downloads root)
+2. Determine correct date (**paid date** from receipt, not invoice/billing period date)
+3. Rename to: `YYYY-MM-DD-Vendor.pdf` (preserve invoice numbers when present in downloaded filename)
+4. Move to `Downloads/YYYY-Mon-Expenses/` folder created in Step 0
+
+**Note:** After workflow complete, user migrates folder contents to archive: `/Users/ncos/Documents/File_cabinet/AMPS Unlimited/Expense Reciepts`
+
+### Step 2b: Verify Against YNAB
+
+Once all receipts are gathered, verify the total against YNAB:
+
+1. Navigate to YNAB (user already logged in from Step 0)
+2. Find the **"Nate Business/Expenses Reimbursable"** category
+3. Check the category activity (shows as negative outflow)
+4. Compare to the total of gathered receipts
+5. **If totals don't match:** STOP and notify user of discrepancy - do not proceed until resolved
+6. **If totals match:** Continue to Step 3
+
+### Step 3: Upload to Zoho Expense
+
+1. Claude navigates to Zoho Expense (user already logged in from Step 0)
+2. Claude prompts user: "Please select all files from `Downloads/YYYY-Mon-Expenses/` using the 'Drag Receipts' area or file picker"
+3. User performs one file selection (drag-drop or picker) - **this is the only manual step during upload**
+4. Zoho auto-extracts data from receipts
+5. Claude verifies each expense entry:
+   - Confirm date matches receipt
+   - Confirm amount matches receipt
+   - Set correct category (reference vendors.md for mappings)
+   - Save entry
+
+**Note:** Zoho allows max 5 files per upload. For months with 6+ receipts, two uploads are needed.
+
+### Step 4: Generate and Submit Expense Report
+
+1. Navigate to Reports in Zoho Expense
+2. Create new expense report:
+   - **Name:** `YYYY Month Expenses` (e.g., "2026 January Expenses")
+   - **Duration:** 1st to last day of month (e.g., 01 Jan 2026 - 31 Jan 2026)
+3. Click "Add Unreported Expenses" and select all expenses for the month
+4. Verify report total matches YNAB balance (already confirmed in Step 2b)
+5. **Submit the report** (YNAB verification passed, so auto-submit is authorized)
+6. Notify user: report submitted, remind to migrate receipt folder to archive
+
+## Browser Automation Notes
+
+**Login workflow:** Navigate to vendor login page, user logs in manually, then Claude assists with navigation and downloads.
+
+**Chrome profile requirements:**
+- Google Workspace requires AMPS Unlimited Chrome profile
+- Other vendors work with personal Chrome profile
+
+**PDF download technique:** When PDFs open in browser viewer and toolbar clicks don't register, use JavaScript:
+```javascript
+const a = document.createElement('a'); a.href = window.location.href; a.download = 'filename.pdf'; a.click();
+```
+
+**When using Claude in Chrome for Zoho Expense:**
+- User must be logged into Zoho before automation
+- Verify each expense entry before saving
+- Take screenshots to confirm successful uploads
+- Check for duplicate entries before creating new ones

--- a/skills/submit-monthly-expenses/assets/example_asset.txt
+++ b/skills/submit-monthly-expenses/assets/example_asset.txt
@@ -1,0 +1,24 @@
+# Example Asset File
+
+This placeholder represents where asset files would be stored.
+Replace with actual asset files (templates, images, fonts, etc.) or delete if not needed.
+
+Asset files are NOT intended to be loaded into context, but rather used within
+the output Claude produces.
+
+Example asset files from other skills:
+- Brand guidelines: logo.png, slides_template.pptx
+- Frontend builder: hello-world/ directory with HTML/React boilerplate
+- Typography: custom-font.ttf, font-family.woff2
+- Data: sample_data.csv, test_dataset.json
+
+## Common Asset Types
+
+- Templates: .pptx, .docx, boilerplate directories
+- Images: .png, .jpg, .svg, .gif
+- Fonts: .ttf, .otf, .woff, .woff2
+- Boilerplate code: Project directories, starter files
+- Icons: .ico, .svg
+- Data files: .csv, .json, .xml, .yaml
+
+Note: This is a text placeholder. Actual assets can be any file type.

--- a/skills/submit-monthly-expenses/references/api_reference.md
+++ b/skills/submit-monthly-expenses/references/api_reference.md
@@ -1,0 +1,34 @@
+# Reference Documentation for Monthly Expenses
+
+This is a placeholder for detailed reference documentation.
+Replace with actual reference content or delete if not needed.
+
+Example real reference docs from other skills:
+- product-management/references/communication.md - Comprehensive guide for status updates
+- product-management/references/context_building.md - Deep-dive on gathering context
+- bigquery/references/ - API references and query examples
+
+## When Reference Docs Are Useful
+
+Reference docs are ideal for:
+- Comprehensive API documentation
+- Detailed workflow guides
+- Complex multi-step processes
+- Information too lengthy for main SKILL.md
+- Content that's only needed for specific use cases
+
+## Structure Suggestions
+
+### API Reference Example
+- Overview
+- Authentication
+- Endpoints with examples
+- Error codes
+- Rate limits
+
+### Workflow Guide Example
+- Prerequisites
+- Step-by-step instructions
+- Common patterns
+- Troubleshooting
+- Best practices

--- a/skills/submit-monthly-expenses/references/vendors.md
+++ b/skills/submit-monthly-expenses/references/vendors.md
@@ -1,0 +1,114 @@
+# Vendor Reference
+
+## File Naming Conventions
+
+- **Date format:** Always use zero-padded dates: `YYYY-MM-DD` (e.g., `2026-01-07`, not `2026-1-7`)
+- **Date used:** Use the **paid date** from the invoice/receipt
+- **Invoice numbers:** When present in downloaded filename, preserve them in the renamed file
+
+## Zoho Expense Categories
+
+| Category | Code | Vendors |
+|----------|------|---------|
+| Bank Fees and Charges | C-II-10 | Zenbusiness Inc. |
+| Insurance | C-II-15 | BiBerk |
+| Legal and Professional Services | C-II-17 | Wyoming Registered Agent Services LLC |
+| Office Expense | C-II-18 | Squarespace |
+| Supplies | C-II-22 | Best Buy, Amazon (equipment) |
+| Software Subscriptions | C-II-27a | Google, AWS, OpenAI/ChatGPT, Toggl, Zoho, GitHub, Anthropic |
+
+## Monthly Recurring Expenses
+
+### Google Workspace
+- **Billing date:** ~1st of month
+- **File name format:** `YYYY-MM-DD-Google Workspace.pdf`
+- **Zoho category:** Software Subscriptions (C-II-27a)
+- **Portal:** admin.google.com → Billing → View payment history
+- **Receipt location:** Payment history → Download invoice
+- **Note:** Requires AMPS Unlimited Chrome profile (separate from personal profile)
+
+### AWS
+- **Billing date:** ~1st of month (invoice date, for previous month's usage)
+- **File name format:** `YYYY-MM-DD-AWS.pdf`
+- **Zoho category:** Software Subscriptions (C-II-27a)
+- **Portal:** console.aws.amazon.com → Billing and Cost Management → Transactions
+- **Receipt location:** Click invoice link to open PDF in browser viewer
+- **Download technique:** Use JavaScript in browser console (PDF viewer toolbar clicks don't register):
+  ```javascript
+  const a = document.createElement('a'); a.href = window.location.href; a.download = 'filename.pdf'; a.click();
+  ```
+
+### WyomingAgents - Virtual Office
+- **Billing date:** ~7th of month (paid date)
+- **File name format:** `YYYY-MM-DD-WyomingAgents - Virtual Office.pdf`
+- **Zoho category:** Legal and Professional Services (C-II-17)
+- **Portal:** accounts.wyomingagents.com → Menu → Account → Invoices
+- **Receipt location:** Select invoice checkbox → Download button
+
+### Zenbusiness Banking
+- **Billing date:** ~18th of month
+- **File name format:** `YYYY-MM-DD-zb-banking-[invoice#].pdf`
+- **Zoho category:** Bank Fees and Charges (C-II-10)
+- **Portal:** zenbusiness.com → Dashboard → My Business → Order History → Download Receipts
+- **Note:** Preserve invoice number from original downloaded filename (e.g., `invoice_3686821.pdf` → `2026-01-18-zb-banking-3686821.pdf`)
+
+## Annual/Periodic Expenses
+
+### WyomingAgents - Registered Agent Service
+- **Billing:** Annual (~June)
+- **File name format:** `YYYY-MM-DD-WyomingAgents - Registered Agent Service.pdf`
+- **Zoho category:** Legal and Professional Services (C-II-17)
+
+### WyomingAgents - Annual Report
+- **Billing:** Annual (~May)
+- **File name format:** `YYYY-MM-DD-WyomingAgents - Annual Report.pdf`
+- **Zoho category:** Legal and Professional Services (C-II-17)
+
+### Biberk Insurance
+- **Billing:** Annual (~March)
+- **Types:** GL, PL, Umbrella, Workers Comp
+- **File name format:** `YYYY-MM-DD-Biberk-[Type].pdf`
+- **Zoho category:** Insurance (C-II-15)
+
+### Zoho
+- **Billing:** Annual (~April)
+- **File name format:** `YYYY-MM-DD-zoho.pdf`
+- **Zoho category:** Software Subscriptions (C-II-27a)
+
+### Toggl
+- **Billing:** Annual (~April)
+- **File name format:** `YYYY-MM-DD-toggl.pdf`
+- **Zoho category:** Software Subscriptions (C-II-27a)
+
+### ChatGPT
+- **Billing:** Monthly or annual
+- **File name format:** `YYYY-MM-DD-ChatGPT.pdf` or `YYYY-MM-DD-ChatGPT-Teams-Annual.pdf`
+- **Zoho category:** Software Subscriptions (C-II-27a)
+
+### Squarespace Domains
+- **Billing:** Annual (~September/October)
+- **File name format:** `YYYY-MM-DD-Squarespace - Domains.pdf`
+- **Zoho category:** Office Expense (C-II-18)
+
+### GitHub
+- **Billing:** Monthly ~15th (includes Copilot; one month/year also includes annual Pro subscription)
+- **File name format:** `YYYY-MM-DD-GitHub.pdf`
+- **Zoho category:** Software Subscriptions (C-II-27a)
+- **Portal:** github.com/settings/billing → Payment history
+- **Receipt location:** Click PDF icon next to transaction to download receipt
+
+### Anthropic
+- **Billing:** Monthly ~26th (Claude Max subscription)
+- **File name format:** `YYYY-MM-DD-Anthropic-Receipt-[invoice#].pdf`
+- **Zoho category:** Software Subscriptions (C-II-27a)
+- **Portal:** claude.ai/settings/billing → Invoices section → Click "View"
+- **Receipt location:** Opens Stripe invoice page → Click "Download receipt" button
+- **Note:** Preserve receipt number from original downloaded filename (e.g., `Receipt-2823-4502-6365.pdf`)
+
+## Ad-hoc Expenses
+
+For one-time purchases (equipment, supplies, travel):
+- Use descriptive vendor name
+- Include brief description if helpful
+- Example: `2024-11-17-Headset-Amazon Order 113-2665686-0520249.pdf`
+- **Zoho category:** Supplies (C-II-22) for equipment/hardware

--- a/skills/submit-monthly-expenses/scripts/example.py
+++ b/skills/submit-monthly-expenses/scripts/example.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""
+Example helper script for monthly-expenses
+
+This is a placeholder script that can be executed directly.
+Replace with actual implementation or delete if not needed.
+
+Example real scripts from other skills:
+- pdf/scripts/fill_fillable_fields.py - Fills PDF form fields
+- pdf/scripts/convert_pdf_to_images.py - Converts PDF pages to images
+"""
+
+def main():
+    print("This is an example script for monthly-expenses")
+    # TODO: Add actual script logic here
+    # This could be data processing, file conversion, API calls, etc.
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Pure migration of `submit-monthly-expenses` skill from `~/.claude/skills/` into this repo at `skills/submit-monthly-expenses/`.
- SKILL.md, scripts/, references/, and assets/ copied verbatim.
- Frontmatter updated to repo standard: `license: MIT`, `metadata.author: natecostello`, `metadata.version: "0.1"`, description folded to `>-` block scalar.
- No rename, no logic changes, no `requirements.txt` (script has no third-party imports).

## Closes
Closes #18

## Plan compliance
- [x] Step 1 (create `skills/submit-monthly-expenses/`) — DONE
- [x] Step 2 (rsync source tree, exclude `.DS_Store`) — DONE
- [x] Step 3 (frontmatter to repo standard with license + metadata) — DONE
- [x] Step 4 (audit hardcoded paths) — DONE: `SKILL.md` notes `/Users/ncos/Documents/...` as the user's archive folder; left as-is since the skill is owner-specific (AMPS Unlimited LLC workflow). `scripts/example.py` is a stub with no paths.
- [x] Step 5 (decide on requirements.txt) — DONE: no third-party imports in `example.py`, none needed.
- [x] Step 6 (commit, open PR) — DONE
- [ ] Step 7 (post-merge install + remove source) — pending merge
- [ ] Step 8 (verify in fresh session) — pending merge

## Test plan
- [x] `./install.sh --list` shows `submit-monthly-expenses` with the description
- [x] Frontmatter valid (`name` matches dir, `license: MIT`, `metadata.author`, `metadata.version` present)
- [x] `references/`, `scripts/`, `assets/` paths preserved
- [ ] Post-merge: `./install.sh --global submit-monthly-expenses` runs clean
- [ ] Post-merge: `~/.claude/skills/submit-monthly-expenses/` removed; symlink in its place points into this repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)